### PR TITLE
Refine layout for rhyme selection page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -842,13 +842,13 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
         {/* Main Content */}
         <div className="flex-1 overflow-hidden">
-          <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-4">
+          <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
 
             {/* Tree Menu */}
             <div
-              className={`lg:col-span-1 transition-all duration-300 ${showTreeMenu ? 'flex' : 'hidden'} ${showTreeMenu ? 'lg:flex' : 'lg:hidden'} h-full min-h-0 flex-col overflow-hidden`}
+              className={`transition-all duration-300 ${showTreeMenu ? 'flex' : 'hidden'} lg:flex h-full min-h-0 flex-col overflow-hidden`}
             >
-              <div className="mb-4 flex-shrink-0">
+              <div className="mb-4 flex-shrink-0 lg:hidden">
                 <Button
                   onClick={() => { setShowTreeMenu(false); setCurrentPosition(null); }}
                   variant="outline"
@@ -874,7 +874,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Dual Container Interface */}
             <div
-              className={`${showTreeMenu ? 'lg:col-span-3' : 'lg:col-span-4'} min-h-0 flex flex-col items-center`}
+              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start"
             >
               <div className="flex h-full w-full max-w-2xl flex-col">
 


### PR DESCRIPTION
## Summary
- switch the rhyme selection grid to a fixed desktop template and always render the menu on large screens
- keep the tree menu close control mobile-only and ensure the carousel column stays anchored with a stable max width

## Testing
- yarn test --watch=false *(fails: registry.yarnpkg.com returned 403 via proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68ce1d08a76083259e9408983c0eecab