### PR TITLE
Add sticky A4 preview layout to rhyme carousel

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,6 +18,23 @@ body {
   min-height: 100vh;
 }
 
+.a4-canvas {
+  width: 100%;
+  max-width: min(100%, 840px);
+  aspect-ratio: 210 / 297;
+  overflow: hidden;
+  position: relative;
+}
+
+.a4-canvas svg {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -874,7 +874,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Dual Container Interface */}
             <div
-              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start"
+              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start lg:sticky lg:top-24"
             >
               <div className="flex h-full w-full max-w-2xl flex-col">
 
@@ -909,9 +909,9 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
-                    <div className="flex h-full items-start justify-center pt-2">
-                      <div className="relative flex h-full w-full max-w-4xl">
-                        <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                    <div className="flex items-start justify-center pt-2">
+                      <div className="relative flex w-full max-w-4xl">
+                        <div className="a4-canvas relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
                           {showBottomContainer && (
                             <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                           )}
@@ -934,7 +934,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
-                                      className="flex h-full w-full items-center justify-center"
+                                      className="flex h-full w-full items-center justify-center [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
                                     />
                                   </div>
                                   <div className="mt-4 space-y-1 text-center">
@@ -986,7 +986,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
-                                        className="flex h-full w-full items-center justify-center"
+                                        className="flex h-full w-full items-center justify-center [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
                                       />
                                     </div>
                                     <div className="mt-4 space-y-1 text-center">


### PR DESCRIPTION
## Summary
- add an `.a4-canvas` utility that constrains the preview to an A4 aspect ratio and keeps embedded SVGs contained
- apply the new canvas class to the carousel preview wrapper and tweak layout sizing so the preview keeps the enforced ratio
- make the rhyme preview column sticky on large screens so the A4 canvas stays visible while adjacent panels scroll

## Testing
- yarn test --watchAll=false *(fails: cannot download Yarn 1.22.22 due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ce22a2158883258898fa9c1a356db6