### PR TITLE
Adjust rhyme selection layout responsiveness

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -810,7 +810,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50">
-      <div className="mx-auto flex h-screen max-w-7xl flex-col items-stretch justify-start overflow-hidden px-4 pt-2 pb-4 sm:px-6">
+      <div className="mx-auto flex min-h-screen max-w-7xl flex-col items-stretch justify-start px-4 pt-2 pb-4 sm:px-6">
         {/* Header */}
         <div className="mb-6 flex flex-shrink-0 flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
@@ -874,7 +874,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Dual Container Interface */}
             <div
-              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start lg:sticky lg:top-24"
+              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start lg:sticky lg:top-24 lg:h-full lg:max-h-[calc(100vh-6rem)]"
             >
               <div className="flex h-full w-full max-w-2xl flex-col">
 
@@ -911,7 +911,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                   <div className="flex-1 min-h-0 pb-6">
                     <div className="flex items-start justify-center pt-2">
                       <div className="relative flex w-full max-w-4xl">
-                        <div className="a4-canvas relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                        <div className="a4-canvas relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl lg:h-full lg:w-auto">
                           {showBottomContainer && (
                             <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                           )}


### PR DESCRIPTION
## Summary
- replace the rhyme selector outer wrapper's fixed viewport height with a min-height layout to allow scrolling when content grows
- constrain the sticky carousel column with a viewport-based max height and allow the A4 canvas to scale down on large screens

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ce313fdadc8325a0311fcfb96c0a34