### PR TITLE
Hide tree menu until requested

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -313,6 +313,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
   const [selectedRhymes, setSelectedRhymes] = useState([]);
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [showTreeMenu, setShowTreeMenu] = useState(false);
+  const treeMenuVisibilityClass = showTreeMenu ? 'flex' : 'hidden';
   const [showReusable, setShowReusable] = useState(false);
   const [currentPosition, setCurrentPosition] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -846,7 +847,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Tree Menu */}
             <div
-              className={`transition-all duration-300 ${showTreeMenu ? 'flex' : 'hidden'} lg:flex h-full min-h-0 flex-col overflow-hidden`}
+              className={`transition-all duration-300 ${treeMenuVisibilityClass} h-full min-h-0 flex-col overflow-hidden`}
             >
               <div className="mb-4 flex-shrink-0 lg:hidden">
                 <Button


### PR DESCRIPTION
## Summary
- compute a shared visibility class for the tree menu so it can be fully toggled on every screen size
- rely on the existing add/replace actions to reopen the selector panel instead of forcing it open on large breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ce3292acac8325b10d205643de61a3