### PR TITLE
Align replace buttons to consistent top-right positioning

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -928,7 +928,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   <Button
                                     onClick={() => handleAddRhyme('top')}
                                     variant="outline"
-                                    className="absolute right-0 sm:right-2 top-3 sm:top-1/2 translate-y-0 sm:-translate-y-1/2 bg-gradient-to-l from-white via-white/90 to-transparent backdrop-blur px-3 sm:px-4 py-2 text-sm text-gray-700 hover:from-white hover:via-white hover:to-white/60 shadow-md"
+                                    className="absolute top-3 right-3 sm:right-4 bg-gradient-to-l from-white via-white/90 to-transparent backdrop-blur px-3 sm:px-4 py-2 text-sm text-gray-700 hover:from-white hover:via-white hover:to-white/60 shadow-md"
                                   >
                                     <Replace className="w-4 h-4 mr-2" />
                                     Replace
@@ -981,7 +981,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     <Button
                                       onClick={() => handleAddRhyme('bottom')}
                                       variant="outline"
-                                      className="absolute right-0 sm:right-2 top-3 sm:top-1/2 translate-y-0 sm:-translate-y-1/2 bg-gradient-to-l from-white via-white/90 to-transparent backdrop-blur px-3 sm:px-4 py-2 text-sm text-gray-700 hover:from-white hover:via-white hover:to-white/60 shadow-md"
+                                      className="absolute top-3 right-3 sm:right-4 bg-gradient-to-l from-white via-white/90 to-transparent backdrop-blur px-3 sm:px-4 py-2 text-sm text-gray-700 hover:from-white hover:via-white hover:to-white/60 shadow-md"
                                     >
                                       <Replace className="w-4 h-4 mr-2" />
                                       Replace


### PR DESCRIPTION
## Summary
- pin both Replace buttons to a consistent top-right offset without relying on vertical translation
- retain the existing gradient overlay so it stays non-interactive while ensuring the buttons remain accessible across viewports

## Testing
- yarn test --watchAll=false *(fails: registry fetch blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce36ab80d48325a86f3864cc4adb9f