### PR TITLE
Animate tree menu slide transition

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -313,7 +313,9 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
   const [selectedRhymes, setSelectedRhymes] = useState([]);
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [showTreeMenu, setShowTreeMenu] = useState(false);
-  const treeMenuVisibilityClass = showTreeMenu ? 'flex' : 'hidden';
+  const treeMenuVisibilityClass = showTreeMenu
+    ? 'translate-x-0 opacity-100 pointer-events-auto'
+    : '-translate-x-full opacity-0 pointer-events-none';
   const [showReusable, setShowReusable] = useState(false);
   const [currentPosition, setCurrentPosition] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -843,11 +845,11 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
         {/* Main Content */}
         <div className="flex-1 overflow-hidden">
-          <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
+          <div className="relative grid h-full grid-cols-1 gap-6 lg:grid-cols-[340px_minmax(0,1fr)]">
 
             {/* Tree Menu */}
             <div
-              className={`transition-all duration-300 ${treeMenuVisibilityClass} h-full min-h-0 flex-col overflow-hidden`}
+              className={`absolute inset-y-0 left-0 z-30 w-72 max-w-full transform bg-white shadow-xl transition-transform transition-opacity duration-300 ease-in-out ${treeMenuVisibilityClass} flex h-full min-h-0 flex-col overflow-hidden lg:static lg:z-auto lg:w-full lg:max-w-none lg:bg-transparent lg:shadow-none lg:opacity-100 lg:pointer-events-auto lg:transform-none`}
             >
               <div className="mb-4 flex-shrink-0 lg:hidden">
                 <Button


### PR DESCRIPTION
## Summary
- replace the tree menu visibility toggle with translate/opacity classes so the menu stays mounted for transitions
- update the tree menu container styling to slide in from the left on small screens while remaining static on large displays

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ce372c0be88325a84d19d87a202c1e