### PR TITLE
Ensure carousel hooks run before loading return

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -792,17 +792,6 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
     return pageRhymes;
   }, [selectedRhymes]);
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-16 h-16 border-4 border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-300">Loading rhyme data...</p>
-        </div>
-      </div>
-    );
-  }
-
   const totalPages = calculateTotalPages();
   const displayTotalPages = Math.max(totalPages, 1);
 
@@ -845,6 +834,17 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
       carouselApi.scrollTo(clampedIndex);
     }
   }, [carouselApi, currentPageIndex, totalPages]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 border-4 border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-gray-300">Loading rhyme data...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-black">


### PR DESCRIPTION
## Summary
- move pagination calculations, callbacks, and carousel effects ahead of the loading guard in `RhymeSelectionPage`
- keep hook logic intact so it runs before the early return

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ceaf3c7b888325b41aa393972ca11b