### PR TITLE
Remove sticky positioning from carousel container

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -912,7 +912,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Dual Container Interface */}
             <div
-              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start lg:sticky lg:top-24 lg:h-full lg:max-h-[calc(100vh-6rem)]"
+              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start"
             >
               <div className="flex h-full w-full max-w-2xl flex-col">
 


### PR DESCRIPTION
## Summary
- remove the large-screen sticky positioning and height constraints from the dual-container carousel wrapper so it scrolls with the page
- keep the carousel container flex layout intact so it remains centered without sticky behavior

## Testing
- npm install *(fails: 403 Forbidden fetching @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_b_68cebd83921c8325a3b88f337aba66e0