### PR TITLE
Adjust A4 canvas dimensions to 210x290

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,20 +19,24 @@ body {
 }
 
 .a4-canvas {
-  width: 100%;
-  max-width: min(100%, 840px);
-  aspect-ratio: 210 / 297;
+  width: 210px;
+  height: 290px;
+  max-width: 210px;
+  max-height: 290px;
   overflow: hidden;
   position: relative;
+  margin: 0 auto;
+  flex: 0 0 auto;
 }
 
 .a4-canvas svg {
   width: 100%;
-  height: 100%;
+  height: auto;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   display: block;
+  margin: 0 auto;
 }
 
 /* Custom scrollbar */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -968,8 +968,8 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                               className="flex h-full w-full justify-center pl-0"
                             >
                               <div className="flex w-full items-start justify-center pt-2">
-                                <div className="relative flex w-full max-w-4xl">
-                                  <div className="a4-canvas relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl lg:h-full lg:w-auto">
+                                <div className="relative flex w-full justify-center">
+                                  <div className="a4-canvas relative flex flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
                                     {showBottomContainer && (
                                       <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                                     )}
@@ -998,7 +998,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                             <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
                                               <div
                                                 dangerouslySetInnerHTML={{ __html: topRhyme.svgContent || '' }}
-                                                className="flex h-full w-full items-center justify-center [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
+                                                className="flex h-full w-full items-center justify-center [&>svg]:h-auto [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
                                               />
                                             </div>
                                             <div className="mt-4 space-y-1 text-center">
@@ -1065,7 +1065,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                               <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
                                                 <div
                                                   dangerouslySetInnerHTML={{ __html: bottomRhyme.svgContent || '' }}
-                                                  className="flex h-full w-full items-center justify-center [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
+                                                  className="flex h-full w-full items-center justify-center [&>svg]:h-auto [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
                                                 />
                                               </div>
                                               <div className="mt-4 space-y-1 text-center">


### PR DESCRIPTION
## Summary
- enforce a fixed 210×290 canvas frame and centered svg scaling in `App.css`
- remove width overrides around the canvas so the carousel centers on the fixed page size
- ensure rendered rhyme SVGs use auto height to avoid distortion inside the frame

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@craco%2fcraco)*

------
https://chatgpt.com/codex/tasks/task_b_68cec108b568832597dd01239e88c51f