### PR TITLE
Disable carousel dragging

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -952,7 +952,12 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                   <div className="flex-1 min-h-0 pb-6">
                     <Carousel
                       className="flex h-full w-full"
-                      opts={{ align: 'center', containScroll: 'trimSnaps' }}
+                      opts={{
+                        align: 'center',
+                        containScroll: 'trimSnaps',
+                        draggable: false,
+                        dragFree: false,
+                      }}
                       setApi={setCarouselApi}
                     >
                       <CarouselContent className="ml-0 h-full">


### PR DESCRIPTION
## Summary
- disable pointer dragging on the carousel by passing draggable and dragFree flags through opts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ced7d315f08325821823ab7e942fc1