### PR TITLE
Adjust tree menu overlay layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -318,9 +318,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
   const treeMenuVisibilityClass = showTreeMenu
     ? 'translate-x-0 opacity-100 pointer-events-auto'
     : '-translate-x-full opacity-0 pointer-events-none';
-  const layoutGridClass = showTreeMenu
-    ? 'lg:grid-cols-[340px_minmax(0,1fr)]'
-    : 'lg:grid-cols-1';
+  const layoutGridClass = 'lg:grid-cols-[minmax(0,1fr)]';
   const [showReusable, setShowReusable] = useState(false);
   const [currentPosition, setCurrentPosition] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -943,7 +941,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Tree Menu */}
             <div
-              className={`absolute inset-y-0 left-0 z-30 w-72 max-w-full transform bg-white shadow-xl transition-transform transition-opacity duration-300 ease-in-out ${treeMenuVisibilityClass} flex h-full min-h-0 flex-col overflow-hidden lg:relative lg:w-full lg:max-w-none`}
+              className={`absolute inset-y-0 left-0 z-30 flex h-full min-h-0 w-72 max-w-full transform flex-col overflow-hidden bg-white shadow-xl transition-transform transition-opacity duration-300 ease-in-out ${treeMenuVisibilityClass} lg:w-80`}
             >
               <div className="mb-4 flex-shrink-0 lg:hidden">
                 <Button


### PR DESCRIPTION
## Summary
- keep the carousel grid layout consistent regardless of the tree menu visibility
- treat the tree menu as an overlay panel with a fixed width so it no longer alters carousel sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cee7804bb483258809aaf7d783fa14