### PR TITLE
Add transition animation for rhyme displays

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -108,6 +108,28 @@ body {
   }
 }
 
+.rhyme-transition {
+  animation: rhymeFadeSlide 0.45s ease-out both;
+  will-change: opacity, transform;
+}
+
+@keyframes rhymeFadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rhyme-transition {
+    animation: none;
+  }
+}
+
 /* Enhanced component styles */
 .fade-in {
   animation: fadeIn 0.6s ease-out;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1026,7 +1026,10 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                         }`}
                                       >
                                         {hasTopRhyme ? (
-                                          <div className="relative flex flex-1 min-h-0 flex-col">
+                                          <div
+                                            key={`${topRhyme?.code ?? 'top-empty'}-${topRhyme?.pages ?? '0'}`}
+                                            className="relative flex flex-1 min-h-0 flex-col rhyme-transition"
+                                          >
                                             <div className="pointer-events-none absolute inset-y-0 right-0 w-20 sm:w-24 bg-gradient-to-l from-white via-white/90 to-transparent" />
                                             <Button
                                               onClick={() => {
@@ -1093,7 +1096,10 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       {showBottomContainer && (
                                         <div className="relative flex-1 min-h-0 p-6 sm:p-8">
                                           {hasBottomRhyme ? (
-                                            <div className="relative flex flex-1 min-h-0 flex-col">
+                                            <div
+                                              key={`${bottomRhyme?.code ?? 'bottom-empty'}-${bottomRhyme?.pages ?? '0'}`}
+                                              className="relative flex flex-1 min-h-0 flex-col rhyme-transition"
+                                            >
                                               <div className="pointer-events-none absolute inset-y-0 right-0 w-20 sm:w-24 bg-gradient-to-l from-white via-white/90 to-transparent" />
                                               <Button
                                                 onClick={() => {


### PR DESCRIPTION
## Summary
- add fade/slide transition wrapper to top and bottom rhyme sections so the SVG and metadata animate together when updated
- define reusable rhyme transition animation with reduced-motion fallback in the stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cef395e7548325b6852dbf3d3eb205