### PR TITLE
Expand carousel artwork frame size

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,27 +18,6 @@ body {
   min-height: 100vh;
 }
 
-.a4-canvas {
-  width: 210px;
-  height: 290px;
-  max-width: 210px;
-  max-height: 290px;
-  overflow: hidden;
-  position: relative;
-  margin: 0 auto;
-  flex: 0 0 auto;
-}
-
-.a4-canvas svg {
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-  display: block;
-  margin: 0 auto;
-}
-
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1055,7 +1055,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                             >
                               <div className="flex w-full items-start justify-center pt-2">
                                 <div className="relative flex w-full justify-center">
-                                  <div className="a4-canvas relative flex flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                                  <div className="relative mx-auto flex h-[580px] w-[420px] max-h-[580px] max-w-[420px] flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-black shadow-2xl">
                                     {showBottomContainer && (
                                       <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                                     )}
@@ -1084,7 +1084,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                               <Replace className="w-4 h-4 mr-2" />
                                               Replace
                                             </Button>
-                                            <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
+                                            <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-black">
                                               <div
                                                 dangerouslySetInnerHTML={{ __html: topRhyme.svgContent || '' }}
                                                 className="flex h-full w-full items-center justify-center [&>svg]:h-auto [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
@@ -1156,7 +1156,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                                 <Replace className="w-4 h-4 mr-2" />
                                                 Replace
                                               </Button>
-                                              <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50">
+                                              <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-black">
                                                 <div
                                                   dangerouslySetInnerHTML={{ __html: bottomRhyme.svgContent || '' }}
                                                   className="flex h-full w-full items-center justify-center [&>svg]:h-auto [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"


### PR DESCRIPTION
## Summary
- replace the carousel's `a4-canvas` wrapper with Tailwind classes that provide a larger centered black frame for SVG artwork
- update the SVG holders to use the new black surface while keeping object-fit utilities intact
- remove the obsolete `.a4-canvas` styles from `App.css`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cefd94320c8325a0e129d9d9a82e64