### PR TITLE
Restore inline replace controls on carousel slots

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import { Separator } from './components/ui/separator';
 import { toast } from 'sonner';
 import { Toaster } from './components/ui/sonner';
 import { Carousel, CarouselContent, CarouselItem } from './components/ui/carousel';
+import DocumentPage from './components/DocumentPage.jsx';
 
 // Icons
 import { Plus, ChevronDown, ChevronRight, Replace, School, Users, BookOpen, Music, ChevronLeft, ChevronUp, Eye } from 'lucide-react';
@@ -331,7 +332,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
   const navigate = useNavigate();
 
   const emptySlotButtonClasses =
-    'flex aspect-square w-32 items-center justify-center rounded-3xl border-2 border-dashed border-orange-300 bg-white/80 text-orange-500 shadow-sm transition-transform duration-300 hover:scale-105 hover:border-orange-400 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400';
+    'group relative flex h-full w-full items-center justify-center rounded-[28px] bg-gradient-to-br from-orange-50 to-amber-50 p-6 text-orange-500 shadow-inner transition-all duration-300 hover:from-orange-100 hover:to-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400';
   const emptySlotIconClasses = 'h-12 w-12';
 
   const MAX_RHYMES_PER_GRADE = 25;
@@ -1043,7 +1044,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                           setApi={setCarouselApi}
                         >
                           <CarouselContent className="ml-0 flex h-full w-full">
-                            {Array.from({ length: displayTotalPages }, (_, pageIndex) => {
+                            {Array.from({ length: displayTotalPages }).map((_, pageIndex) => {
                               const pageRhymes = getPageRhymes(pageIndex);
                               const topRhyme = pageRhymes.top;
                               const bottomRhyme = pageRhymes.bottom;
@@ -1052,126 +1053,77 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                               const isTopFullPage = hasTopRhyme && parsePagesValue(topRhyme.pages) === 1;
                               const showBottomContainer = !isTopFullPage;
 
+                              const openSlot = (position) => {
+                                if (pageIndex !== currentPageIndex) {
+                                  handlePageChange(pageIndex);
+                                }
+                                handleAddRhyme(position);
+                              };
+
+                              const renderSvgSlot = (rhyme, position) => (
+                                <div className="group relative flex h-full w-full min-h-0 min-w-0 items-center justify-center overflow-hidden bg-white">
+                                  <div
+                                    dangerouslySetInnerHTML={{ __html: rhyme?.svgContent || '' }}
+                                    className="pointer-events-none h-full w-full p-6 [&>svg]:block [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
+                                  />
+                                  <Button
+                                    type="button"
+                                    onClick={() => openSlot(position)}
+                                    variant="outline"
+                                    className="absolute right-4 top-4 z-10 flex items-center gap-2 bg-white/90 px-3 py-2 text-sm font-medium text-gray-700 shadow-md backdrop-blur transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+                                    aria-label={`Replace ${position} rhyme`}
+                                  >
+                                    <Replace className="h-4 w-4" aria-hidden="true" />
+                                    <span>Replace</span>
+                                  </Button>
+                                </div>
+                              );
+
                               return (
                                 <CarouselItem
                                   key={pageIndex}
                                   className="flex h-full w-full justify-center"
                                 >
-                                  <div className="flex w-full items-start justify-center py-4">
-                                    <div className="relative flex w-full justify-center px-2 sm:px-4">
-                                      <div className="relative mx-auto w-full max-w-[480px]">
-                                        <div className="relative aspect-[210/290] w-full">
-                                          <div className="absolute inset-0 flex flex-col overflow-hidden rounded-[32px] border border-gray-200 bg-white shadow-2xl">
-                                            <div className={`grid h-full min-h-0 ${showBottomContainer ? 'grid-rows-2' : 'grid-rows-1'}`}>
-                                              <section className="relative flex flex-col bg-white">
-                                                {hasTopRhyme ? (
-                                                  <div
-                                                    key={`${topRhyme?.code ?? 'top-empty'}-${topRhyme?.pages ?? '0'}`}
-                                                    className="relative flex flex-1 min-h-0 flex-col"
-                                                  >
-                                                    <Button
-                                                      onClick={() => {
-                                                        if (pageIndex !== currentPageIndex) {
-                                                          handlePageChange(pageIndex);
-                                                        }
-                                                        handleAddRhyme('top');
-                                                      }}
-                                                      variant="outline"
-                                                      className="absolute right-4 top-4 z-10 bg-white/90 px-3 py-2 text-sm text-gray-700 shadow-md backdrop-blur hover:bg-white"
-                                                    >
-                                                      <Replace className="mr-2 h-4 w-4" />
-                                                      Replace
-                                                    </Button>
-                                                    <div className="flex flex-1 min-h-0 items-center justify-center bg-white px-6 py-6">
-                                                      <div
-                                                        dangerouslySetInnerHTML={{ __html: topRhyme.svgContent || '' }}
-                                                        className="max-h-full max-w-full [&>svg]:h-auto [&>svg]:w-auto [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
-                                                      />
-                                                    </div>
-                                                    <div className="px-6 pb-6 text-center">
-                                                      <p className="font-semibold text-gray-800">{topRhyme.name}</p>
-                                                      <p className="text-sm text-gray-500">
-                                                        Code: {topRhyme.code} • Pages: {topRhyme.pages}
-                                                      </p>
-                                                    </div>
-                                                  </div>
-                                                ) : (
-                                                  <div className="flex flex-1 items-center justify-center px-6 py-6">
-                                                    <button
-                                                      type="button"
-                                                      onClick={() => {
-                                                        if (pageIndex !== currentPageIndex) {
-                                                          handlePageChange(pageIndex);
-                                                        }
-                                                        handleAddRhyme('top');
-                                                      }}
-                                                      className={emptySlotButtonClasses}
-                                                      aria-label="Add rhyme to top slot"
-                                                    >
-                                                      <Plus className={emptySlotIconClasses} aria-hidden="true" />
-                                                      <span className="sr-only">Add rhyme to top slot</span>
-                                                    </button>
-                                                  </div>
-                                                )}
-                                              </section>
+                                  <div className="flex w-full justify-center py-4">
+                                    <div className="flex w-full max-w-[520px] flex-col items-center gap-4 px-2 sm:px-4">
+                                      <DocumentPage
+                                        showBottom={showBottomContainer}
+                                        topSlot={
+                                          hasTopRhyme ? (
+                                            renderSvgSlot(topRhyme, 'top')
+                                          ) : (
+                                            <button
+                                              type="button"
+                                              onClick={() => openSlot('top')}
+                                              className={emptySlotButtonClasses}
+                                              aria-label="Add rhyme to top slot"
+                                            >
+                                              <span className="flex h-full w-full items-center justify-center rounded-3xl border-2 border-dashed border-orange-300 bg-white/70 text-orange-500 shadow-inner transition-all duration-300 group-hover:border-orange-400 group-hover:bg-white group-hover:text-orange-600">
+                                                <Plus className={emptySlotIconClasses} aria-hidden="true" />
+                                              </span>
+                                            </button>
+                                          )
+                                        }
+                                        bottomSlot={
+                                          showBottomContainer
+                                            ? hasBottomRhyme
+                                              ? renderSvgSlot(bottomRhyme, 'bottom')
+                                              : (
+                                                <button
+                                                  type="button"
+                                                  onClick={() => openSlot('bottom')}
+                                                  className={emptySlotButtonClasses}
+                                                  aria-label="Add rhyme to bottom slot"
+                                                >
+                                                  <span className="flex h-full w-full items-center justify-center rounded-3xl border-2 border-dashed border-orange-300 bg-white/70 text-orange-500 shadow-inner transition-all duration-300 group-hover:border-orange-400 group-hover:bg-white group-hover:text-orange-600">
+                                                    <Plus className={emptySlotIconClasses} aria-hidden="true" />
+                                                  </span>
+                                                </button>
+                                              )
+                                            : null
+                                        }
+                                      />
 
-                                              {showBottomContainer && (
-                                                <section className="relative flex flex-col bg-white">
-                                                  {hasBottomRhyme ? (
-                                                    <div
-                                                      key={`${bottomRhyme?.code ?? 'bottom-empty'}-${bottomRhyme?.pages ?? '0'}`}
-                                                      className="relative flex flex-1 min-h-0 flex-col"
-                                                    >
-                                                      <Button
-                                                        onClick={() => {
-                                                          if (pageIndex !== currentPageIndex) {
-                                                            handlePageChange(pageIndex);
-                                                          }
-                                                          handleAddRhyme('bottom');
-                                                        }}
-                                                        variant="outline"
-                                                        className="absolute right-4 top-4 z-10 bg-white/90 px-3 py-2 text-sm text-gray-700 shadow-md backdrop-blur hover:bg-white"
-                                                      >
-                                                        <Replace className="mr-2 h-4 w-4" />
-                                                        Replace
-                                                      </Button>
-                                                      <div className="flex flex-1 min-h-0 items-center justify-center bg-white px-6 py-6">
-                                                        <div
-                                                          dangerouslySetInnerHTML={{ __html: bottomRhyme.svgContent || '' }}
-                                                          className="max-h-full max-w-full [&>svg]:h-auto [&>svg]:w-auto [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
-                                                        />
-                                                      </div>
-                                                      <div className="px-6 pb-6 text-center">
-                                                        <p className="font-semibold text-gray-800">{bottomRhyme.name}</p>
-                                                        <p className="text-sm text-gray-500">
-                                                          Code: {bottomRhyme.code} • Pages: {bottomRhyme.pages}
-                                                        </p>
-                                                      </div>
-                                                    </div>
-                                                  ) : (
-                                                    <div className="flex flex-1 items-center justify-center px-6 py-6">
-                                                      <button
-                                                        type="button"
-                                                        onClick={() => {
-                                                          if (pageIndex !== currentPageIndex) {
-                                                            handlePageChange(pageIndex);
-                                                          }
-                                                          handleAddRhyme('bottom');
-                                                        }}
-                                                        className={emptySlotButtonClasses}
-                                                        aria-label="Add rhyme to bottom slot"
-                                                      >
-                                                        <Plus className={emptySlotIconClasses} aria-hidden="true" />
-                                                        <span className="sr-only">Add rhyme to bottom slot</span>
-                                                      </button>
-                                                    </div>
-                                                  )}
-                                                </section>
-                                              )}
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
                                     </div>
                                   </div>
                                 </CarouselItem>

--- a/frontend/src/components/DocumentPage.jsx
+++ b/frontend/src/components/DocumentPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { cn } from '../lib/utils';
+
+const DocumentPage = ({ topSlot, bottomSlot, showBottom = true, className }) => {
+  return (
+    <div className={cn('relative aspect-[210/297] w-full', className)}>
+      <div className="flex h-full w-full min-h-0 min-w-0 overflow-hidden rounded-[32px] border border-gray-200 bg-white shadow-2xl">
+        <div className={cn('grid h-full w-full min-h-0', showBottom ? 'grid-rows-2' : 'grid-rows-1')}>
+          <div className="relative flex h-full min-h-0 w-full items-stretch overflow-hidden">{topSlot}</div>
+          {showBottom && (
+            <div className="relative flex h-full min-h-0 w-full items-stretch overflow-hidden">{bottomSlot}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DocumentPage;


### PR DESCRIPTION
## Summary
- restore the replace button overlay inside each document slot so the replace control appears on the container like before while keeping the SVG scaling layout intact

## Testing
- not run (registry 403 prevents installing npm dependencies)


------
https://chatgpt.com/codex/tasks/task_b_68d04665fba48325bdc84e79cd0b864d