### PR TITLE
Fix missing container close in renderSvgSlot

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1077,6 +1077,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   >
                                     <Replace className="h-5 w-5" aria-hidden="true" />
                                   </button>
+                                </div>
 
                               );
 


### PR DESCRIPTION
## Summary
- close the container div returned by `renderSvgSlot` so carousel content renders valid JSX

## Testing
- `npm --prefix frontend run build` *(fails: craco not found in environment)*
- `npm --prefix frontend install` *(fails: registry access for @craco/craco is forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68d0638e238c8325b2b9c657c6010796