### PR TITLE
Fix JSX wrapper closing in RhymeSelectionPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1063,23 +1063,24 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                               };
 
 
-                              const renderSvgSlot = (rhyme, position) => (
-                                <div className="group relative flex h-full w-full min-h-0 min-w-0 items-center justify-center overflow-hidden bg-white">
-                                  <div
-                                    dangerouslySetInnerHTML={{ __html: rhyme?.svgContent || '' }}
-                                    className="pointer-events-none h-full w-full p-6 [&>svg]:block [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
-                                  />
-                                  <button
-                                    type="button"
-                                    onClick={() => openSlot(position)}
-                                    className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-orange-500 shadow transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-orange-400 focus:ring-offset-2"
-                                    aria-label={`Replace ${position} rhyme`}
-                                  >
-                                    <Replace className="h-5 w-5" aria-hidden="true" />
-                                  </button>
-                                </div>
-
-                              );
+                              const renderSvgSlot = (rhyme, position) => {
+                                return (
+                                  <div className="group relative flex h-full w-full min-h-0 min-w-0 items-center justify-center overflow-hidden bg-white">
+                                    <div
+                                      dangerouslySetInnerHTML={{ __html: rhyme?.svgContent || '' }}
+                                      className="pointer-events-none h-full w-full p-6 [&>svg]:block [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
+                                    />
+                                    <button
+                                      type="button"
+                                      onClick={() => openSlot(position)}
+                                      className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-orange-500 shadow transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-orange-400 focus:ring-offset-2"
+                                      aria-label={`Replace ${position} rhyme`}
+                                    >
+                                      <Replace className="h-5 w-5" aria-hidden="true" />
+                                    </button>
+                                  </div>
+                                );
+                              };
 
                               return (
                                 <CarouselItem


### PR DESCRIPTION
## Summary
- wrap the `renderSvgSlot` helper in a block arrow function so its wrapper `<div>` is returned with the proper closing tag

## Testing
- npm --prefix frontend run build *(fails: `craco` command not found because dev dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d0684edd6c8325a5639bfe8e2f38c7