### PR TITLE
Remove horizontal gutters from carousel layout

### DIFF
--- a/frontend/src/components/ui/carousel.jsx
+++ b/frontend/src/components/ui/carousel.jsx
@@ -121,7 +121,7 @@ const CarouselContent = React.forwardRef(({ className, ...props }, ref) => {
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          orientation === "horizontal" ? null : "-mt-4 flex-col",
           className
         )}
         {...props} />
@@ -140,7 +140,7 @@ const CarouselItem = React.forwardRef(({ className, ...props }, ref) => {
       aria-roledescription="slide"
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        orientation === "horizontal" ? null : "pt-4",
         className
       )}
       {...props} />


### PR DESCRIPTION
## Summary
- remove the default horizontal offset classes from the shared carousel components so slides align with their parent containers

## Testing
- yarn test --watchAll=false *(fails: unable to download yarn binary due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d0df93ea9c83258c1ebeb1c83b4d0b