### PR TITLE
Eliminate carousel horizontal spacing

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1034,7 +1034,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                     <div
                       className={`flex h-full w-full justify-center transition-[padding] duration-300 ${showTreeMenu ? 'lg:pl-80 xl:pl-[22rem]' : ''}`}
                     >
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
+                      <div className="relative flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white py-4 shadow-xl sm:py-6">
                         <Carousel
                           className="flex h-full w-full justify-center"
                           opts={{
@@ -1045,7 +1045,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                           }}
                           setApi={setCarouselApi}
                         >
-                          <CarouselContent className="ml-0 flex h-full w-full">
+                          <CarouselContent className="flex h-full w-full">
                             {Array.from({ length: displayTotalPages }, (_, pageIndex) => {
                               const pageRhymes = getPageRhymes(pageIndex);
                               const topRhyme = pageRhymes.top;
@@ -1088,7 +1088,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   className="flex h-full w-full justify-center"
                                 >
                                   <div className="flex w-full justify-center py-4">
-                                    <div className="flex w-full max-w-[520px] flex-col items-center gap-4 px-2 sm:px-4">
+                                    <div className="flex w-full max-w-[520px] flex-col items-center gap-4">
                                       <DocumentPage
                                         showBottom={showBottomContainer}
                                         topSlot={

--- a/frontend/src/components/ui/carousel.jsx
+++ b/frontend/src/components/ui/carousel.jsx
@@ -121,7 +121,7 @@ const CarouselContent = React.forwardRef(({ className, ...props }, ref) => {
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          orientation === "horizontal" ? null : "-mt-4 flex-col",
           className
         )}
         {...props} />
@@ -140,7 +140,7 @@ const CarouselItem = React.forwardRef(({ className, ...props }, ref) => {
       aria-roledescription="slide"
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        orientation === "horizontal" ? null : "pt-4",
         className
       )}
       {...props} />


### PR DESCRIPTION
## Summary
- remove the carousel card's horizontal padding so the viewport extends flush to its parent container
- strip slide-level horizontal padding to keep each page spanning the available width without affecting vertical layout

## Testing
- yarn test --watchAll=false *(fails: proxy 403 when downloading Yarn package manager binary)*

------
https://chatgpt.com/codex/tasks/task_b_68d0df93ea9c83258c1ebeb1c83b4d0b