### PR TITLE
Remove carousel outer padding while keeping internal spacing

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1034,9 +1034,9 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                     <div
                       className={`flex h-full w-full justify-center transition-[padding] duration-300 ${showTreeMenu ? 'lg:pl-80 xl:pl-[22rem]' : ''}`}
                     >
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
+                      <div className="relative flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white py-4 shadow-xl sm:py-6">
                         <Carousel
-                          className="flex h-full w-full justify-center"
+                          className="flex h-full w-full"
                           opts={{
                             align: 'center',
                             containScroll: 'trimSnaps',


### PR DESCRIPTION
## Summary
- remove the global `.container`/`.card` overrides so carousel items retain their original inner spacing
- update the carousel wrapper to drop horizontal margin/padding while keeping vertical spacing unchanged
- restore the Embla carousel offsets to maintain slide gutters while the content is flush with its parent

## Testing
- yarn test --watchAll=false *(fails: proxy 403 when downloading Yarn binary)*

------
https://chatgpt.com/codex/tasks/task_b_68d0df93ea9c83258c1ebeb1c83b4d0b