### PR TITLE
Center rhyme carousel and align document layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -334,8 +334,8 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
   const navigate = useNavigate();
 
   const emptySlotButtonClasses =
-    'group relative flex h-full w-full items-center justify-center rounded-[28px] bg-gradient-to-br from-orange-50 to-amber-50 p-6 text-orange-500 shadow-inner transition-all duration-300 hover:from-orange-100 hover:to-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400';
-  const emptySlotIconClasses = 'h-12 w-12';
+    'group relative flex h-full w-full items-center justify-center bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400';
+  const emptySlotIconClasses = 'h-10 w-10';
 
   const MAX_RHYMES_PER_GRADE = 25;
 
@@ -983,12 +983,12 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
             {/* Dual Container Interface */}
             <div
-              className="min-h-0 flex w-full max-w-4xl flex-col items-center self-start"
+              className="min-h-0 flex w-full flex-col items-center"
             >
-              <div className="flex h-full w-full max-w-2xl flex-col">
+              <div className="flex w-full flex-col items-center">
 
                 {/* Navigation Controls */}
-                <div className="flex-shrink-0 space-y-3 pb-1">
+                <div className="w-[210mm] flex-shrink-0 space-y-3 pb-1">
                   <div className="flex items-center justify-between">
                     <Button
                       onClick={() => handlePageChange(Math.max(0, currentPageIndex - 1))}
@@ -1031,159 +1031,102 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
-                    <div
-                      className={`flex h-full w-full justify-center transition-[padding] duration-300 ${showTreeMenu ? 'lg:pl-80 xl:pl-[22rem]' : ''}`}
-                    >
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
-                        <Carousel
-                          className="flex h-full w-full justify-center"
-                          opts={{
-                            align: 'center',
-                            containScroll: 'trimSnaps',
-                            draggable: false,
-                            dragFree: false,
-                          }}
-                          setApi={setCarouselApi}
-                        >
-                          <CarouselContent className="ml-0 flex h-full w-full">
-                            {Array.from({ length: displayTotalPages }, (_, pageIndex) => {
-                              const pageRhymes = getPageRhymes(pageIndex);
-                              const topRhyme = pageRhymes.top;
-                              const bottomRhyme = pageRhymes.bottom;
-                              const hasTopRhyme = topRhyme !== null;
-                              const hasBottomRhyme = bottomRhyme !== null;
-                              const isTopFullPage = hasTopRhyme && parsePagesValue(topRhyme.pages) === 1;
-                              const showBottomContainer = !isTopFullPage;
+                    <div className="flex h-full w-full justify-center">
+                      <Carousel
+                        className="mx-auto w-[210mm]"
+                        opts={{
+                          align: 'center',
+                          containScroll: 'trimSnaps',
+                          draggable: false,
+                          dragFree: false,
+                        }}
+                        setApi={setCarouselApi}
+                      >
+                        <CarouselContent hasSpacing={false} className="flex h-full w-full">
+                          {Array.from({ length: displayTotalPages }, (_, pageIndex) => {
+                            const pageRhymes = getPageRhymes(pageIndex);
+                            const topRhyme = pageRhymes.top;
+                            const bottomRhyme = pageRhymes.bottom;
+                            const hasTopRhyme = topRhyme !== null;
+                            const hasBottomRhyme = bottomRhyme !== null;
+                            const isTopFullPage = hasTopRhyme && parsePagesValue(topRhyme.pages) === 1;
+                            const showBottomContainer = !isTopFullPage;
 
-                              const openSlot = (position) => {
-                                if (pageIndex !== currentPageIndex) {
-                                  handlePageChange(pageIndex);
-                                }
-                                handleAddRhyme(position);
-                              };
+                            const openSlot = (position) => {
+                              if (pageIndex !== currentPageIndex) {
+                                handlePageChange(pageIndex);
+                              }
+                              handleAddRhyme(position);
+                            };
 
-
-                              const renderSvgSlot = (rhyme, position) => {
-                                return (
-                                  <div className="group relative flex h-full w-full min-h-0 min-w-0 items-center justify-center overflow-hidden bg-white">
-                                    <div
-                                      dangerouslySetInnerHTML={{ __html: rhyme?.svgContent || '' }}
-                                      className="pointer-events-none h-full w-full p-6 [&>svg]:block [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain [&>svg]:mx-auto"
-                                    />
-                                    <button
-                                      type="button"
-                                      onClick={() => openSlot(position)}
-                                      className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-orange-500 shadow transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-orange-400 focus:ring-offset-2"
-                                      aria-label={`Replace ${position} rhyme`}
-                                    >
-                                      <Replace className="h-5 w-5" aria-hidden="true" />
-                                    </button>
-                                  </div>
-                                );
-                              };
-
+                            const renderSvgSlot = (rhyme, position) => {
                               return (
-                                <CarouselItem
-                                  key={pageIndex}
-                                  className="flex h-full w-full justify-center"
-                                >
-                                  <div className="flex w-full justify-center py-4">
-                                    <div className="flex w-full max-w-[520px] flex-col items-center gap-4 px-2 sm:px-4">
-                                      <DocumentPage
-                                        showBottom={showBottomContainer}
-                                        topSlot={
-                                          hasTopRhyme ? (
-
-                                            renderSvgSlot(topRhyme, 'top')
-
-                                          ) : (
-                                            <button
-                                              type="button"
-                                              onClick={() => openSlot('top')}
-                                              className={emptySlotButtonClasses}
-                                              aria-label="Add rhyme to top slot"
-                                            >
-                                              <span className="flex h-full w-full items-center justify-center rounded-3xl border-2 border-dashed border-orange-300 bg-white/70 text-orange-500 shadow-inner transition-all duration-300 group-hover:border-orange-400 group-hover:bg-white group-hover:text-orange-600">
-                                                <Plus className={emptySlotIconClasses} aria-hidden="true" />
-                                              </span>
-                                            </button>
-                                          )
-                                        }
-                                        bottomSlot={
-                                          showBottomContainer
-                                            ? hasBottomRhyme
-                                              ? renderSvgSlot(bottomRhyme, 'bottom')
-
-                                          
-
-                                              : (
-                                                <button
-                                                  type="button"
-                                                  onClick={() => openSlot('bottom')}
-                                                  className={emptySlotButtonClasses}
-                                                  aria-label="Add rhyme to bottom slot"
-                                                >
-                                                  <span className="flex h-full w-full items-center justify-center rounded-3xl border-2 border-dashed border-orange-300 bg-white/70 text-orange-500 shadow-inner transition-all duration-300 group-hover:border-orange-400 group-hover:bg-white group-hover:text-orange-600">
-                                                    <Plus className={emptySlotIconClasses} aria-hidden="true" />
-                                                  </span>
-                                                </button>
-                                              )
-                                            : null
-                                        }
-                                      />
-
-
-
-                                      <div className="grid w-full gap-3">
-                                        {hasTopRhyme && (
-                                          <div className="flex flex-col items-center justify-between gap-3 rounded-2xl bg-white/80 p-4 text-center shadow-sm backdrop-blur-sm sm:flex-row sm:text-left">
-                                            <div>
-                                              <p className="font-semibold text-gray-800">{topRhyme.name}</p>
-                                              <p className="text-xs text-gray-500">
-                                                Code: {topRhyme.code} • Pages: {topRhyme.pages}
-                                              </p>
-                                            </div>
-                                            <Button
-                                              onClick={() => openSlot('top')}
-                                              variant="outline"
-                                              size="sm"
-                                              className="w-full sm:w-auto"
-                                            >
-                                              <Replace className="mr-2 h-4 w-4" />
-                                              Replace
-                                            </Button>
-                                          </div>
-                                        )}
-
-                                        {showBottomContainer && hasBottomRhyme && (
-                                          <div className="flex flex-col items-center justify-between gap-3 rounded-2xl bg-white/80 p-4 text-center shadow-sm backdrop-blur-sm sm:flex-row sm:text-left">
-                                            <div>
-                                              <p className="font-semibold text-gray-800">{bottomRhyme.name}</p>
-                                              <p className="text-xs text-gray-500">
-                                                Code: {bottomRhyme.code} • Pages: {bottomRhyme.pages}
-                                              </p>
-                                            </div>
-                                            <Button
-                                              onClick={() => openSlot('bottom')}
-                                              variant="outline"
-                                              size="sm"
-                                              className="w-full sm:w-auto"
-                                            >
-                                              <Replace className="mr-2 h-4 w-4" />
-                                              Replace
-                                            </Button>
-                                          </div>
-                                        )}
-                                      </div>
-
-                                    </div>
-                                  </div>
-                                </CarouselItem>
+                                <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-white">
+                                  <div
+                                    dangerouslySetInnerHTML={{ __html: rhyme?.svgContent || '' }}
+                                    className="pointer-events-none flex h-full w-full items-center justify-center [&>svg]:block [&>svg]:h-full [&>svg]:w-full [&>svg]:max-h-full [&>svg]:max-w-full [&>svg]:object-contain"
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => openSlot(position)}
+                                    className="absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center bg-white/90 text-orange-500 transition hover:text-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-400"
+                                    aria-label={`Replace ${position} rhyme`}
+                                  >
+                                    <Replace className="h-4 w-4" aria-hidden="true" />
+                                  </button>
+                                </div>
                               );
-                            })}
-                          </CarouselContent>
-                        </Carousel>
-                      </div>
+                            };
+
+                            return (
+                              <CarouselItem
+                                key={pageIndex}
+                                hasSpacing={false}
+                                className="flex justify-center"
+                              >
+                                <DocumentPage
+                                  className="flex-none"
+                                  showBottom={showBottomContainer}
+                                  topSlot={
+                                    hasTopRhyme ? (
+                                      renderSvgSlot(topRhyme, 'top')
+                                    ) : (
+                                      <button
+                                        type="button"
+                                        onClick={() => openSlot('top')}
+                                        className={emptySlotButtonClasses}
+                                        aria-label="Add rhyme to top slot"
+                                      >
+                                        <span className="flex h-full w-full items-center justify-center border border-dashed border-orange-300 text-orange-500 transition-colors duration-300 group-hover:border-orange-400 group-hover:text-orange-600">
+                                          <Plus className={emptySlotIconClasses} aria-hidden="true" />
+                                        </span>
+                                      </button>
+                                    )
+                                  }
+                                  bottomSlot={
+                                    showBottomContainer
+                                      ? hasBottomRhyme
+                                        ? renderSvgSlot(bottomRhyme, 'bottom')
+                                        : (
+                                          <button
+                                            type="button"
+                                            onClick={() => openSlot('bottom')}
+                                            className={emptySlotButtonClasses}
+                                            aria-label="Add rhyme to bottom slot"
+                                          >
+                                            <span className="flex h-full w-full items-center justify-center border border-dashed border-orange-300 text-orange-500 transition-colors duration-300 group-hover:border-orange-400 group-hover:text-orange-600">
+                                              <Plus className={emptySlotIconClasses} aria-hidden="true" />
+                                            </span>
+                                          </button>
+                                        )
+                                      : null
+                                  }
+                                />
+                              </CarouselItem>
+                            );
+                          })}
+                        </CarouselContent>
+                      </Carousel>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/DocumentPage.jsx
+++ b/frontend/src/components/DocumentPage.jsx
@@ -2,17 +2,25 @@ import React from 'react';
 import { cn } from '../lib/utils';
 
 const DocumentPage = ({ topSlot, bottomSlot, showBottom = true, className }) => {
+  const isFullPage = !showBottom;
+
   return (
-    <div className={cn('relative aspect-[210/297] w-full', className)}>
-      <div className="flex h-full w-full min-h-0 min-w-0 overflow-hidden rounded-[32px] border border-gray-200 bg-white shadow-2xl">
-        <div className={cn('grid h-full w-full min-h-0', showBottom ? 'grid-rows-2' : 'grid-rows-1')}>
-
-          <div className="relative flex h-full min-h-0 w-full items-stretch overflow-hidden">{topSlot}</div>
-          {showBottom && (
-            <div className="relative flex h-full min-h-0 w-full items-stretch overflow-hidden">{bottomSlot}</div>
-          )}
-
-        </div>
+    <div className={cn('w-full flex justify-center', className)}>
+      <div className="w-[210mm] h-[290mm] bg-white flex flex-col">
+        {isFullPage ? (
+          <div className="flex-1 flex items-center justify-center">
+            {topSlot}
+          </div>
+        ) : (
+          <>
+            <div className="flex-1 flex items-center justify-center">
+              {topSlot}
+            </div>
+            <div className="flex-1 flex items-center justify-center">
+              {bottomSlot}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ui/carousel.jsx
+++ b/frontend/src/components/ui/carousel.jsx
@@ -112,7 +112,7 @@ const Carousel = React.forwardRef((
 })
 Carousel.displayName = "Carousel"
 
-const CarouselContent = React.forwardRef(({ className, ...props }, ref) => {
+const CarouselContent = React.forwardRef(({ className, hasSpacing = true, ...props }, ref) => {
   const { carouselRef, orientation } = useCarousel()
 
   return (
@@ -121,7 +121,13 @@ const CarouselContent = React.forwardRef(({ className, ...props }, ref) => {
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          hasSpacing
+            ? orientation === "horizontal"
+              ? "-ml-4"
+              : "-mt-4 flex-col"
+            : orientation === "vertical"
+              ? "flex-col"
+              : null,
           className
         )}
         {...props} />
@@ -130,7 +136,7 @@ const CarouselContent = React.forwardRef(({ className, ...props }, ref) => {
 })
 CarouselContent.displayName = "CarouselContent"
 
-const CarouselItem = React.forwardRef(({ className, ...props }, ref) => {
+const CarouselItem = React.forwardRef(({ className, hasSpacing = true, ...props }, ref) => {
   const { orientation } = useCarousel()
 
   return (
@@ -140,7 +146,11 @@ const CarouselItem = React.forwardRef(({ className, ...props }, ref) => {
       aria-roledescription="slide"
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        hasSpacing
+          ? orientation === "horizontal"
+            ? "pl-4"
+            : "pt-4"
+          : null,
         className
       )}
       {...props} />


### PR DESCRIPTION
## Summary
- keep the rhyme carousel locked to a centered A4 width so it no longer shifts or gains side gaps when adding or replacing rhymes
- render the document page as a centered 210mm × 290mm sheet, switching between single and split halves without extra spacing to match the required structure
- streamline empty slot and replace controls so opening them doesn’t stretch the layout
- remove the built-in Embla carousel padding so the viewport stays perfectly centered without extra right gutter space

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d0d3d1467883258ff48ddd97f2e266