### PR TITLE
Adjust carousel wrappers to allow full width

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1031,10 +1031,10 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
-                    <div className="flex h-full w-full justify-center">
+                    <div className="h-full w-full">
                       <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
                         <Carousel
-                          className="flex h-full w-full justify-center"
+                          className="relative h-full w-full"
                           opts={{
                             align: 'center',
                             containScroll: 'trimSnaps',


### PR DESCRIPTION
## Summary
- remove flexbox centering from the rhyme preview wrappers so the Embla carousel can stretch across its container
- keep the carousel wrapper relative while allowing it to expand to the available width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d147630e7083259c9c772dc942f810