### PR TITLE
Remove flex centering from carousel wrapper

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1032,7 +1032,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
                     <div className="h-full w-full">
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
+                      <div className="relative mx-auto h-full w-full max-w-5xl rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
                         <Carousel
                           className="relative h-full w-full"
                           opts={{
@@ -1083,7 +1083,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                               return (
                                 <CarouselItem
                                   key={pageIndex}
-                                  className="flex h-full w-full justify-center"
+                                  className="h-full w-full"
                                   hasSpacing={false}
                                 >
                                   <div className="flex w-full justify-center py-4">


### PR DESCRIPTION
## Summary
- remove flex centering from the rhyme selection carousel wrapper so the Embla viewport keeps full width
- drop unneeded flex justification on each carousel item to prevent slides from shrinking when the first rhyme loads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d1465627f08325845d754a50a6827f