### PR TITLE
Fix missing div closure in RhymeSelectionPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1174,7 +1174,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
       </div>
     </div>
-    
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- close the outer container div in RhymeSelectionPage so the markup is balanced

## Testing
- npm run build *(fails: craco command missing because dependencies could not be installed due to 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68d1886c57888325bab9caea2d5e12e6