### PR TITLE
Disable spacing in carousel layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1043,7 +1043,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                           }}
                           setApi={setCarouselApi}
                         >
-                          <CarouselContent className="ml-0 flex h-full w-full">
+                          <CarouselContent className="flex h-full w-full" hasSpacing={false}>
                             {Array.from({ length: displayTotalPages }, (_, pageIndex) => {
                               const pageRhymes = getPageRhymes(pageIndex);
                               const topRhyme = pageRhymes.top;
@@ -1084,6 +1084,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                 <CarouselItem
                                   key={pageIndex}
                                   className="flex h-full w-full justify-center"
+                                  hasSpacing={false}
                                 >
                                   <div className="flex w-full justify-center py-4">
                                     <div className="flex w-full max-w-[520px] flex-col items-center gap-4">


### PR DESCRIPTION
## Summary
- disable Embla spacing for the carousel content so slides align flush with container
- remove per-item spacing to eliminate unintended left padding on rhyme slides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d196b67f948325a8bbc80128acf5fb