### PR TITLE
Adjust carousel container padding

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1032,7 +1032,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
                     <div className="flex h-full w-full justify-center">
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white p-4 shadow-xl sm:p-6">
+                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white py-4 shadow-xl sm:py-6">
                         <Carousel
                           className="flex h-full w-full justify-center"
                           opts={{


### PR DESCRIPTION
## Summary
- replace the carousel wrapper padding with vertical-only utilities to remove horizontal spacing
- allow the rhyme slides to sit flush against the rounded container edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d19c71c47c832591e15d75b0cf0284