### PR TITLE
Expand carousel to full width

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1037,8 +1037,8 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
 
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 pb-6">
-                    <div className="flex h-full w-full justify-center">
-                      <div className="relative mx-auto flex h-full w-full max-w-5xl justify-center rounded-[36px] bg-white py-4 shadow-xl sm:py-6">
+                    <div className="flex h-full w-full">
+                      <div className="relative flex h-full w-full justify-center rounded-[36px] bg-white py-4 shadow-xl sm:py-6">
                         <Carousel
                           className="flex h-full w-full justify-center"
                           opts={{


### PR DESCRIPTION
## Summary
- remove the max-width constraint and centering wrapper around the rhyme carousel
- allow the carousel container to stretch the full width of its parent layout panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d231c286248325b714f48ddd90a6fa