### PR TITLE
Add PDF download for selected rhymes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,5 @@ python-multipart>=0.0.9
 jq>=1.6.0
 typer>=0.9.0
 google-auth>=2.35.0
+cairosvg>=2.7.0
+reportlab>=4.2.0


### PR DESCRIPTION
## Summary
- add a PDF export endpoint that converts submitted rhyme SVGs into vertically stacked pages
- document the new cairosvg/reportlab dependencies for PDF generation
- surface a download button once a grade is filled and request the PDF from the backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d27b5fcafc83258cec34240b16e602