### PR TITLE
Add backend URL fallback for frontend API calls

### DIFF
--- a/frontend/src/AdminDashboard.js
+++ b/frontend/src/AdminDashboard.js
@@ -11,8 +11,7 @@ import { Skeleton } from './components/ui/skeleton';
 
 import { ArrowLeft, RefreshCcw, Trash2 } from 'lucide-react';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+import { API_BASE_URL as API } from './config';
 
 const GRADE_LABELS = {
   nursery: 'Nursery',

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,8 +22,7 @@ import DocumentPage from './components/DocumentPage.jsx';
 // Icons
 import { Plus, ChevronDown, ChevronRight, Replace, School, Users, BookOpen, Music, ChevronLeft, ChevronUp, Eye, Download } from 'lucide-react';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+import { API_BASE_URL as API } from './config';
 
 // Authentication Page
 const AuthPage = ({ onAuth }) => {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,30 @@
+const sanitizeUrl = (url) => url.replace(/\/+$/, '');
+
+const computeBackendUrl = () => {
+  const envUrl = process.env.REACT_APP_BACKEND_URL;
+  if (envUrl && envUrl.trim()) {
+    return sanitizeUrl(envUrl.trim());
+  }
+
+  if (typeof window !== 'undefined' && window.location) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        'REACT_APP_BACKEND_URL is not set. Falling back to http://localhost:8000 for development.',
+      );
+      return 'http://localhost:8000';
+    }
+
+    console.warn(
+      'REACT_APP_BACKEND_URL is not set. Falling back to current origin for backend requests.',
+    );
+    return sanitizeUrl(window.location.origin);
+  }
+
+  console.warn(
+    'REACT_APP_BACKEND_URL is not set and window is unavailable. Falling back to http://localhost:8000.',
+  );
+  return 'http://localhost:8000';
+};
+
+export const BACKEND_URL = computeBackendUrl();
+export const API_BASE_URL = `${BACKEND_URL}/api`;


### PR DESCRIPTION
## Summary
- centralize frontend API configuration in a new config module
- fall back to sensible defaults when REACT_APP_BACKEND_URL is not provided
- update App and AdminDashboard to use the shared API base configuration

## Testing
- `yarn install --frozen-lockfile` *(fails: blocked from downloading yarn 1.22.22 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d2961e35ec83258a7d00e3d2a55d3d