### PR TITLE
Add PDF binder download for completed grade selections

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -10,26 +10,67 @@ import json
 from pathlib import Path
 from pydantic import BaseModel, Field
 from typing import List, Dict, Optional, Any
+from io import BytesIO
+
+from cairosvg import svg2png
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
 import uuid
 from datetime import datetime
 
 ROOT_DIR = Path(__file__).parent
-load_dotenv(ROOT_DIR / '.env')
+load_dotenv(ROOT_DIR / ".env")
 
 # MongoDB connection
-mongo_url = os.environ['MONGO_URL']
+mongo_url = os.environ["MONGO_URL"]
 client = AsyncIOMotorClient(mongo_url)
-db = client[os.environ['DB_NAME']]
+db = client[os.environ["DB_NAME"]]
 
 # Load rhymes data
-with open(ROOT_DIR / 'rhymes.json', 'r') as f:
+with open(ROOT_DIR / "rhymes.json", "r") as f:
     RHYMES_DATA = json.load(f)
+
+
+def generate_rhyme_svg(rhyme_code: str) -> str:
+    """Create SVG markup for a rhyme card.
+
+    This helper centralizes the SVG generation so that both the API endpoint
+    returning individual SVGs and the binder export can share the same layout.
+    """
+
+    if rhyme_code not in RHYMES_DATA:
+        raise KeyError("Rhyme not found")
+
+    rhyme_name = RHYMES_DATA[rhyme_code][0]
+
+    return f"""
+    <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" style="stop-color:#ff6b6b;stop-opacity:1" />
+                <stop offset="100%" style="stop-color:#4ecdc4;stop-opacity:1" />
+            </linearGradient>
+        </defs>
+        <rect width="400" height="300" fill="url(#grad1)" rx="15"/>
+        <text x="200" y="100" font-family="Arial, sans-serif" font-size="16" font-weight="bold"
+              text-anchor="middle" fill="white">{rhyme_name}</text>
+        <text x="200" y="130" font-family="Arial, sans-serif" font-size="12"
+              text-anchor="middle" fill="white">Code: {rhyme_code}</text>
+        <text x="200" y="160" font-family="Arial, sans-serif" font-size="12"
+              text-anchor="middle" fill="white">Pages: {RHYMES_DATA[rhyme_code][1]}</text>
+        <circle cx="200" cy="220" r="30" fill="rgba(255,255,255,0.3)" stroke="white" stroke-width="2"/>
+        <text x="200" y="225" font-family="Arial, sans-serif" font-size="20"
+              text-anchor="middle" fill="white">♪</text>
+    </svg>
+    """
 
 
 app = FastAPI()
 
 # Create a router with the /api prefix
 api_router = APIRouter(prefix="/api")
+
 
 # Models
 class School(BaseModel):
@@ -38,9 +79,11 @@ class School(BaseModel):
     school_name: str
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
+
 class SchoolCreate(BaseModel):
     school_id: str
     school_name: str
+
 
 class RhymeSelection(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -53,12 +96,14 @@ class RhymeSelection(BaseModel):
     position: str = "top"
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
+
 class RhymeSelectionCreate(BaseModel):
     school_id: str
     grade: str
     page_index: int
     rhyme_code: str
     position: Optional[str] = None
+
 
 class GradeStatus(BaseModel):
     grade: str
@@ -81,109 +126,116 @@ class SchoolWithSelections(School):
     last_updated: Optional[datetime] = None
     grades: Dict[str, List[RhymeSelectionDetail]] = Field(default_factory=dict)
 
+
 # Authentication endpoints
 @api_router.post("/auth/login", response_model=School)
 async def login_school(input: SchoolCreate):
     # Check if school already exists
     existing_school = await db.schools.find_one({"school_id": input.school_id})
-    
+
     if existing_school:
         return School(**existing_school)
-    
+
     # Create new school entry
     school_dict = input.dict()
     school_obj = School(**school_dict)
     await db.schools.insert_one(school_obj.dict())
     return school_obj
 
+
 # Rhymes data endpoints
 @api_router.get("/rhymes")
 async def get_all_rhymes():
     """Get all rhymes organized by pages"""
     rhymes_by_pages = {}
-    
+
     for code, data in RHYMES_DATA.items():
         name, pages, personalized = data
         page_key = str(pages)
-        
+
         if page_key not in rhymes_by_pages:
             rhymes_by_pages[page_key] = []
-        
-        rhymes_by_pages[page_key].append({
-            "code": code,
-            "name": name,
-            "pages": pages,
-            "personalized": personalized
-        })
-    
+
+        rhymes_by_pages[page_key].append(
+            {"code": code, "name": name, "pages": pages, "personalized": personalized}
+        )
+
     return rhymes_by_pages
 
+
 @api_router.get("/rhymes/available/{school_id}/{grade}")
-async def get_available_rhymes(school_id: str, grade: str, include_selected: bool = False):
+async def get_available_rhymes(
+    school_id: str, grade: str, include_selected: bool = False
+):
     """Get available rhymes for a specific grade"""
     if not include_selected:
         # Get already selected rhymes for ALL grades in this school
-        selected_rhymes = await db.rhyme_selections.find({
-            "school_id": school_id
-        }).to_list(None)
-        
+        selected_rhymes = await db.rhyme_selections.find(
+            {"school_id": school_id}
+        ).to_list(None)
+
         selected_codes = {selection["rhyme_code"] for selection in selected_rhymes}
     else:
         selected_codes = set()
-    
+
     # Get available rhymes organized by pages
     rhymes_by_pages = {}
-    
+
     for code, data in RHYMES_DATA.items():
         if code not in selected_codes:  # Only include unselected rhymes
             name, pages, personalized = data
             page_key = str(pages)
-            
+
             if page_key not in rhymes_by_pages:
                 rhymes_by_pages[page_key] = []
-            
-            rhymes_by_pages[page_key].append({
-                "code": code,
-                "name": name,
-                "pages": pages,
-                "personalized": personalized
-            })
-    
+
+            rhymes_by_pages[page_key].append(
+                {
+                    "code": code,
+                    "name": name,
+                    "pages": pages,
+                    "personalized": personalized,
+                }
+            )
+
     return rhymes_by_pages
+
 
 @api_router.get("/rhymes/selected/{school_id}")
 async def get_selected_rhymes(school_id: str):
     """Get all selected rhymes for a school organized by grade"""
     selections = await db.rhyme_selections.find({"school_id": school_id}).to_list(None)
-    
+
     result = {}
     for selection in selections:
         grade = selection["grade"]
         if grade not in result:
             result[grade] = []
-        
-        result[grade].append({
-            "page_index": selection["page_index"],
-            "code": selection["rhyme_code"],
-            "name": selection["rhyme_name"],
-            "pages": selection["pages"],
-            "position": selection.get("position")
-        })
-    
+
+        result[grade].append(
+            {
+                "page_index": selection["page_index"],
+                "code": selection["rhyme_code"],
+                "name": selection["rhyme_name"],
+                "pages": selection["pages"],
+                "position": selection.get("position"),
+            }
+        )
+
     # Sort by page_index
     for grade in result:
         result[grade].sort(key=lambda x: x["page_index"])
-    
+
     return result
+
 
 @api_router.get("/rhymes/selected/other-grades/{school_id}/{grade}")
 async def get_selected_rhymes_other_grades(school_id: str, grade: str):
     """Get rhymes selected in other grades that can be reused"""
-    selections = await db.rhyme_selections.find({
-        "school_id": school_id,
-        "grade": {"$ne": grade}  # Exclude current grade
-    }).to_list(None)
-    
+    selections = await db.rhyme_selections.find(
+        {"school_id": school_id, "grade": {"$ne": grade}}  # Exclude current grade
+    ).to_list(None)
+
     # Get unique rhymes from other grades
     selected_rhymes = {}
     for selection in selections:
@@ -193,10 +245,10 @@ async def get_selected_rhymes_other_grades(school_id: str, grade: str):
                 "code": code,
                 "name": selection["rhyme_name"],
                 "pages": selection["pages"],
-                "used_in_grades": []
+                "used_in_grades": [],
             }
         selected_rhymes[code]["used_in_grades"].append(selection["grade"])
-    
+
     # Organize by pages
     rhymes_by_pages = {}
     for rhyme in selected_rhymes.values():
@@ -204,8 +256,9 @@ async def get_selected_rhymes_other_grades(school_id: str, grade: str):
         if page_key not in rhymes_by_pages:
             rhymes_by_pages[page_key] = []
         rhymes_by_pages[page_key].append(rhyme)
-    
+
     return rhymes_by_pages
+
 
 @api_router.post("/rhymes/select", response_model=RhymeSelection)
 async def select_rhyme(input: RhymeSelectionCreate):
@@ -213,19 +266,21 @@ async def select_rhyme(input: RhymeSelectionCreate):
     # Check if rhyme exists
     if input.rhyme_code not in RHYMES_DATA:
         raise HTTPException(status_code=404, detail="Rhyme not found")
-    
+
     rhyme_data = RHYMES_DATA[input.rhyme_code]
-    
+
     pages = float(rhyme_data[1])
 
     # Normalize position (half-page rhymes can occupy top or bottom)
     requested_position = (input.position or "").strip().lower()
-    normalized_position = "bottom" if pages == 0.5 and requested_position == "bottom" else "top"
+    normalized_position = (
+        "bottom" if pages == 0.5 and requested_position == "bottom" else "top"
+    )
 
     page_query = {
         "school_id": input.school_id,
         "grade": input.grade,
-        "page_index": input.page_index
+        "page_index": input.page_index,
     }
 
     existing_selections = await db.rhyme_selections.find(page_query).to_list(None)
@@ -254,16 +309,15 @@ async def select_rhyme(input: RhymeSelectionCreate):
 
     # Create new selection
     selection_dict = input.dict()
-    selection_dict.update({
-        "rhyme_name": rhyme_data[0],
-        "pages": pages,
-        "position": normalized_position
-    })
-    
+    selection_dict.update(
+        {"rhyme_name": rhyme_data[0], "pages": pages, "position": normalized_position}
+    )
+
     selection_obj = RhymeSelection(**selection_dict)
     await db.rhyme_selections.insert_one(selection_obj.dict())
-    
+
     return selection_obj
+
 
 # @api_router.delete("/rhymes/remove/{school_id}/{grade}/{page_index}")
 # async def remove_rhyme_selection(school_id: str, grade: str, page_index: int):
@@ -273,27 +327,31 @@ async def select_rhyme(input: RhymeSelectionCreate):
 #         "grade": grade,
 #         "page_index": page_index
 #     })
-    
+
 #     if result.deleted_count == 0:
 #         raise HTTPException(status_code=404, detail="Selection not found")
-    
+
 #     return {"message": "Selection removed successfully"}
 
+
 @api_router.delete("/rhymes/remove/{school_id}/{grade}/{page_index}/{position}")
-async def remove_specific_rhyme_selection(school_id: str, grade: str, page_index : int, position: str):
+async def remove_specific_rhyme_selection(
+    school_id: str, grade: str, page_index: int, position: str
+):
     """Remove a specific rhyme selection for a position (top/bottom)"""
     # Get all selections for this page
-    selections = await db.rhyme_selections.find({
-        "school_id": school_id,
-        "grade": grade,
-        "page_index": page_index,
-        
-    }).to_list(None)
-    
+    selections = await db.rhyme_selections.find(
+        {
+            "school_id": school_id,
+            "grade": grade,
+            "page_index": page_index,
+        }
+    ).to_list(None)
+
     if not selections:
         # raise HTTPException(status_code=404, detail="No selections found for this page")
-        return {"message":f"selection is removed"}
-    
+        return {"message": f"selection is removed"}
+
     # Find and remove the specific position rhyme
     target_position = position.lower()
     selection_to_remove = None
@@ -322,40 +380,42 @@ async def remove_specific_rhyme_selection(school_id: str, grade: str, page_index
             if target_position == "bottom" and selection.get("pages") == 0.5:
                 selection_to_remove = selection
                 break
-    
+
     if not selection_to_remove:
-        raise HTTPException(status_code=404, detail="Selection not found for the specified position")
+        raise HTTPException(
+            status_code=404, detail="Selection not found for the specified position"
+        )
 
     # Remove the selection
-    result = await db.rhyme_selections.delete_one({
-        "_id": selection_to_remove["_id"]
-    })
-    
+    result = await db.rhyme_selections.delete_one({"_id": selection_to_remove["_id"]})
+
     if result.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Selection not found")
-    
+
     return {"message": f"{position.capitalize()} selection removed successfully"}
+
 
 @api_router.get("/rhymes/status/{school_id}")
 async def get_grade_status(school_id: str):
     """Get selection status for all grades"""
     grades = ["nursery", "lkg", "ukg", "playgroup"]
     status = []
-    
+
     for grade in grades:
-        selections = await db.rhyme_selections.find({
-            "school_id": school_id,
-            "grade": grade
-        }).to_list(None)
-        
+        selections = await db.rhyme_selections.find(
+            {"school_id": school_id, "grade": grade}
+        ).to_list(None)
+
         selected_count = len(selections)
-        
-        status.append({
-            "grade": grade,
-            "selected_count": selected_count,
-            "total_available": 25  # Maximum 25 rhymes can be selected
-        })
-    
+
+        status.append(
+            {
+                "grade": grade,
+                "selected_count": selected_count,
+                "total_available": 25,  # Maximum 25 rhymes can be selected
+            }
+        )
+
     return status
 
 
@@ -371,9 +431,9 @@ async def get_all_schools_with_selections():
 
     selection_docs = []
     if school_ids:
-        selection_docs = await db.rhyme_selections.find({
-            "school_id": {"$in": school_ids}
-        }).to_list(None)
+        selection_docs = await db.rhyme_selections.find(
+            {"school_id": {"$in": school_ids}}
+        ).to_list(None)
 
     selections_by_school: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
     latest_selection_timestamp: Dict[str, datetime] = {}
@@ -481,37 +541,125 @@ async def delete_school(school_id: str):
         "removed_selections": selection_result.deleted_count,
     }
 
+
 @api_router.get("/rhymes/svg/{rhyme_code}")
 async def get_rhyme_svg(rhyme_code: str):
     """Get SVG content for a rhyme (mock implementation)"""
-    if rhyme_code not in RHYMES_DATA:
+    try:
+        svg_content = generate_rhyme_svg(rhyme_code)
+    except KeyError:
         raise HTTPException(status_code=404, detail="Rhyme not found")
-    
-    rhyme_name = RHYMES_DATA[rhyme_code][0]
-    
-    # Mock SVG content since we can't access the network path in development
-    svg_content = f'''
-    <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-            <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style="stop-color:#ff6b6b;stop-opacity:1" />
-                <stop offset="100%" style="stop-color:#4ecdc4;stop-opacity:1" />
-            </linearGradient>
-        </defs>
-        <rect width="400" height="300" fill="url(#grad1)" rx="15"/>
-        <text x="200" y="100" font-family="Arial, sans-serif" font-size="16" font-weight="bold" 
-              text-anchor="middle" fill="white">{rhyme_name}</text>
-        <text x="200" y="130" font-family="Arial, sans-serif" font-size="12" 
-              text-anchor="middle" fill="white">Code: {rhyme_code}</text>
-        <text x="200" y="160" font-family="Arial, sans-serif" font-size="12" 
-              text-anchor="middle" fill="white">Pages: {RHYMES_DATA[rhyme_code][1]}</text>
-        <circle cx="200" cy="220" r="30" fill="rgba(255,255,255,0.3)" stroke="white" stroke-width="2"/>
-        <text x="200" y="225" font-family="Arial, sans-serif" font-size="20" 
-              text-anchor="middle" fill="white">♪</text>
-    </svg>
-    '''
-    
+
     return Response(content=svg_content, media_type="image/svg+xml")
+
+
+@api_router.get("/rhymes/binder/{school_id}/{grade}")
+async def download_rhyme_binder(school_id: str, grade: str):
+    """Generate a PDF binder containing all rhymes for the specified grade."""
+
+    selections = await db.rhyme_selections.find(
+        {
+            "school_id": school_id,
+            "grade": grade,
+        }
+    ).to_list(None)
+
+    if not selections:
+        raise HTTPException(status_code=404, detail="No rhymes selected for this grade")
+
+    pages_map: Dict[int, List[Dict[str, Any]]] = {}
+
+    for selection in selections:
+        page_index = int(selection.get("page_index", 0))
+        pages_map.setdefault(page_index, []).append(selection)
+
+    buffer = BytesIO()
+    pdf_canvas = canvas.Canvas(buffer, pagesize=letter)
+    page_width, page_height = letter
+
+    for page_index in sorted(pages_map.keys()):
+        entries = pages_map[page_index]
+        # Sort so that "top" entries are rendered before "bottom"
+        entries.sort(
+            key=lambda item: (
+                1 if (item.get("position") or "top").lower() == "bottom" else 0
+            )
+        )
+
+        full_page_entry = next(
+            (item for item in entries if float(item.get("pages", 1)) > 0.5), None
+        )
+
+        if full_page_entry:
+            try:
+                svg_markup = generate_rhyme_svg(full_page_entry["rhyme_code"])
+            except KeyError:
+                continue
+
+            image_buffer = BytesIO()
+            svg2png(
+                bytestring=svg_markup.encode("utf-8"),
+                write_to=image_buffer,
+                output_width=int(page_width),
+                output_height=int(page_height),
+            )
+            image_buffer.seek(0)
+            pdf_canvas.drawImage(
+                ImageReader(image_buffer), 0, 0, width=page_width, height=page_height
+            )
+        else:
+            slot_height = page_height / 2
+            positioned_entries: Dict[str, Optional[Dict[str, Any]]] = {
+                "top": None,
+                "bottom": None,
+            }
+
+            for entry in entries:
+                position = (entry.get("position") or "top").lower()
+                if position not in positioned_entries:
+                    position = "top"
+                if positioned_entries[position] is None:
+                    positioned_entries[position] = entry
+
+            for position, entry in positioned_entries.items():
+                if not entry:
+                    continue
+
+                try:
+                    svg_markup = generate_rhyme_svg(entry["rhyme_code"])
+                except KeyError:
+                    continue
+
+                image_buffer = BytesIO()
+                svg2png(
+                    bytestring=svg_markup.encode("utf-8"),
+                    write_to=image_buffer,
+                    output_width=int(page_width),
+                    output_height=int(slot_height),
+                )
+                image_buffer.seek(0)
+
+                y_position = page_height - slot_height if position == "top" else 0
+                pdf_canvas.drawImage(
+                    ImageReader(image_buffer),
+                    0,
+                    y_position,
+                    width=page_width,
+                    height=slot_height,
+                )
+
+        pdf_canvas.showPage()
+
+    pdf_canvas.save()
+    buffer.seek(0)
+
+    filename = f"{grade}_rhyme_binder.pdf"
+    headers = {"Content-Disposition": f"attachment; filename={filename}"}
+
+    return Response(
+        content=buffer.getvalue(), media_type="application/pdf", headers=headers
+    )
+
 
 # Include the router in the main app
 app.include_router(api_router)
@@ -519,17 +667,17 @@ app.include_router(api_router)
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,
-    allow_origins=os.environ.get('CORS_ORIGINS', '*').split(','),
+    allow_origins=os.environ.get("CORS_ORIGINS", "*").split(","),
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
 
 @app.on_event("shutdown")
 async def shutdown_db_client():

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,7 @@ import { Toaster } from './components/ui/sonner';
 
 
 // Icons
-import { Plus, ChevronDown, ChevronRight, Replace, School, Users, BookOpen, Music, ChevronLeft, ChevronUp, Eye } from 'lucide-react';
+import { Plus, ChevronDown, ChevronRight, Replace, School, Users, BookOpen, Music, ChevronLeft, ChevronUp, Eye, Download } from 'lucide-react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
@@ -133,6 +133,31 @@ const GradeSelectionPage = ({ school, onGradeSelect, onLogout }) => {
     return status ? `${status.selected_count} of 25` : '0 of 25';
   };
 
+  const handleDownloadBinder = async (gradeId, event) => {
+    event?.stopPropagation();
+    event?.preventDefault();
+
+    try {
+      const response = await axios.get(`${API}/rhymes/binder/${school.school_id}/${gradeId}`, {
+        responseType: 'blob'
+      });
+
+      const blob = new Blob([response.data], { type: 'application/pdf' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', `${gradeId}-rhyme-binder.pdf`);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+      toast.success('Binder download started');
+    } catch (error) {
+      console.error('Error downloading binder:', error);
+      toast.error('Failed to download binder');
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center">
@@ -170,7 +195,7 @@ const GradeSelectionPage = ({ school, onGradeSelect, onLogout }) => {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {grades.map((grade) => (
-            <Card 
+            <Card
               key={grade.id}
               className="group cursor-pointer transition-all duration-300 hover:scale-105 hover:shadow-2xl border-0 bg-white/80 backdrop-blur-sm"
               onClick={() => onGradeSelect(grade.id)}
@@ -183,11 +208,29 @@ const GradeSelectionPage = ({ school, onGradeSelect, onLogout }) => {
                 <Badge variant="secondary" className="mb-4">
                   {getGradeStatusInfo(grade.id)} Rhymes Selected
                 </Badge>
-                <Button 
-                  className={`w-full bg-gradient-to-r ${grade.color} hover:opacity-90 text-white font-semibold rounded-xl transition-all duration-300`}
-                >
-                  Select Rhymes
-                </Button>
+                <div className="space-y-3">
+                  <Button
+                    className={`w-full bg-gradient-to-r ${grade.color} hover:opacity-90 text-white font-semibold rounded-xl transition-all duration-300`}
+                  >
+                    Select Rhymes
+                  </Button>
+                  {(() => {
+                    const status = gradeStatus.find(s => s.grade === grade.id);
+                    const isComplete = status ? status.selected_count >= 25 : false;
+                    if (!isComplete) return null;
+
+                    return (
+                      <Button
+                        variant="outline"
+                        onClick={(event) => handleDownloadBinder(grade.id, event)}
+                        className="w-full flex items-center justify-center gap-2 border-orange-300 text-orange-500 hover:text-orange-600 hover:bg-orange-50 bg-white/90"
+                      >
+                        <Download className="w-4 h-4" />
+                        Download Binder
+                      </Button>
+                    );
+                  })()}
+                </div>
               </CardContent>
             </Card>
           ))}


### PR DESCRIPTION
## Summary
- add a shared SVG generator and new `/rhymes/binder` API endpoint to build PDF binders from selected rhymes
- show a Download Binder action on grade cards once 25 rhymes are selected so schools can grab the PDF

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d4368e560c83259d5cbd4d6fc4d19a