### PR TITLE
Improve binder SVG rendering reliability

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ jq>=1.6.0
 typer>=0.9.0
 cairosvg>=2.7.0
 reportlab>=4.2.0
+svglib>=1.5.1


### PR DESCRIPTION
## Summary
- add structured PDF dependency loading that supports CairoSVG or svglib renderers
- reuse a shared helper to draw SVG content when building the binder PDF and improve the fallback message
- declare svglib as an optional backend dependency for the PDF generator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d530022f0c8325872690207ecd6fc9