### PR TITLE
Improve rhyme preview scaling and layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -132,19 +132,32 @@ body {
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
 }
 
+.a4-preview {
+  width: min(100%, 900px);
+  aspect-ratio: 210 / 297;
+  max-height: calc(100vh - 160px);
+}
+
+@media (max-width: 1024px) {
+  .a4-preview {
+    max-height: calc(100vh - 120px);
+  }
+}
+
 .rhyme-svg-content {
+  position: relative;
   display: flex;
   width: 100%;
+  height: 100%;
   max-width: 100%;
-  aspect-ratio: 210 / 297;
   align-items: center;
   justify-content: center;
   overflow: hidden;
 }
 
 .rhyme-svg-content svg {
-  width: 100%;
-  height: auto;
+  width: 100% !important;
+  height: auto !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -971,13 +971,13 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 <div className="flex-1 min-h-0 py-4">
                     <div className="flex h-full items-center justify-center">
                       <div className="relative flex w-full max-w-4xl justify-center">
-                        <div className="relative flex aspect-[210/297] w-full max-w-[900px] max-h-[80vh] flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                        <div className="a4-preview relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
                           {showBottomContainer && (
                             <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                           )}
                           <div className="flex h-full flex-col">
                             <div
-                              className={`relative flex flex-1 min-h-0 flex-col p-6 sm:p-8 ${
+                              className={`relative flex flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 ${
                                 showBottomContainer ? 'border-b border-gray-200' : ''
                               }`}
                             >
@@ -991,7 +991,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     <Replace className="w-4 h-4 mr-2" />
                                     Replace
                                   </Button>
-                                  <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-4">
+                                  <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
                                       className="rhyme-svg-content"
@@ -1015,7 +1015,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                             </div>
 
                             {showBottomContainer && (
-                              <div className="relative flex-1 min-h-0 p-6 sm:p-8">
+                              <div className="relative flex-1 min-h-0 p-4 sm:p-6 lg:p-8">
                                 {hasBottomRhyme ? (
                                   <div className="relative flex flex-1 min-h-0 flex-col">
                                     <Button
@@ -1026,7 +1026,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       <Replace className="w-4 h-4 mr-2" />
                                       Replace
                                     </Button>
-                                    <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-4">
+                                    <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
                                         className="rhyme-svg-content"


### PR DESCRIPTION
## Summary
- ensure the rhyme preview shell keeps an A4 aspect ratio while fitting within the viewport
- tighten SVG wrapper styling so artwork scales inside its container without cropping
- adjust padding on the top and bottom rhyme panels so both remain visible inside the preview

## Testing
- npm run build *(fails: craco not found in PATH in this environment)*
- npm install *(fails: registry returned 403 for @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_b_68d6298cf540832593ffe8a753ac2e25