### PR TITLE
Adjust rhyme preview layout and remove page prompt

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,20 +133,21 @@ body {
 }
 
 .a4-preview {
-  width: min(100%, 900px);
+  width: min(100%, 210mm);
   aspect-ratio: 210 / 297;
-  max-height: calc(100vh - 160px);
+  max-height: min(calc(100vh - 160px), 297mm);
 }
 
 @media (max-width: 1024px) {
   .a4-preview {
-    max-height: calc(100vh - 120px);
+    max-height: min(calc(100vh - 120px), 297mm);
   }
 }
 
 .rhyme-svg-content {
   position: relative;
   display: flex;
+  flex: 1 1 auto;
   width: 100%;
   height: 100%;
   max-width: 100%;
@@ -157,7 +158,7 @@ body {
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: auto !important;
+  height: 100% !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -946,29 +946,10 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                       <ChevronRight className="w-4 h-4 ml-1" />
                     </Button>
                   </div>
-
-                  <div className="flex items-center justify-center">
-                    {hasNextPageCapacity ? (
-                      <Button
-                        onClick={() => handlePageChange(nextAvailablePageIndex)}
-                        variant="outline"
-                        size="sm"
-                        disabled={nextAvailablePageIndex === currentPageIndex}
-                      >
-                        {nextAvailablePageIndex === currentPageIndex
-                          ? `Viewing Page ${nextAvailablePageIndex + 1}`
-                          : `Go to Page ${nextAvailablePageIndex + 1}`}
-                      </Button>
-                    ) : (
-                      <span className="text-sm text-gray-500">
-                        All {MAX_RHYMES_PER_GRADE} pages are currently filled.
-                      </span>
-                    )}
-                  </div>
                 </div>
 
                 <div className="flex-1 min-h-0 flex flex-col">
-                <div className="flex-1 min-h-0 py-4">
+                  <div className="flex-1 min-h-0 py-4">
                     <div className="flex h-full items-center justify-center">
                       <div className="relative flex w-full max-w-4xl justify-center">
                         <div className="a4-preview relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">


### PR DESCRIPTION
## Summary
- align the carousel preview container with A4 proportions for more accurate rhyme previews
- ensure rhyme SVGs scale to fully occupy their container without clipping
- remove the go-to-page prompt button from the rhyme selection view

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d63e006fc083258730a9e3dbbea91f