### PR TITLE
Ensure rhyme containers scale to full width

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -149,8 +149,9 @@ body {
   display: flex;
   flex: 1 1 auto;
   width: 100%;
-  height: 100%;
+  height: auto;
   max-width: 100%;
+  max-height: 100%;
   align-items: center;
   justify-content: center;
   overflow: hidden;
@@ -158,11 +159,20 @@ body {
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: 100% !important;
+  height: auto !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   display: block;
+}
+
+.rhyme-slot {
+  width: 100%;
+}
+
+.rhyme-slot-container {
+  width: 100%;
+  height: 100%;
 }
 
 /* Button enhancements */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1275,7 +1275,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                             <div
                               className={`relative flex flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 ${
                                 showBottomContainer ? 'border-b border-gray-200' : ''
-                              }`}
+                              } rhyme-slot`}
                             >
                               {hasTopRhyme ? (
                                 <div className="relative flex flex-1 min-h-0 flex-col">
@@ -1287,7 +1287,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     <Replace className="w-4 h-4 mr-2" />
                                     Replace
                                   </Button>
-                                  <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
+                                  <div className="rhyme-slot-container flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
                                       className="rhyme-svg-content"
@@ -1307,7 +1307,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                             </div>
 
                             {showBottomContainer && (
-                              <div className="relative flex-1 min-h-0 p-4 sm:p-6 lg:p-8">
+                              <div className="relative flex flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 rhyme-slot">
                                 {hasBottomRhyme ? (
                                   <div className="relative flex flex-1 min-h-0 flex-col">
                                     <Button
@@ -1318,7 +1318,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       <Replace className="w-4 h-4 mr-2" />
                                       Replace
                                     </Button>
-                                    <div className="flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
+                                    <div className="rhyme-slot-container flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
                                         className="rhyme-svg-content"


### PR DESCRIPTION
## Summary
- ensure both top and bottom rhyme slots stretch to the full width of their container
- add utility classes so embedded rhyme SVGs scale proportionally without distortion

## Testing
- npm install *(fails: 403 Forbidden fetching @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_b_68d66ff76fa88325922ab75341a10917