### PR TITLE
Improve rhyme SVG scaling on desktop preview

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -146,22 +146,21 @@ body {
 
 .rhyme-svg-content {
   position: relative;
-  display: flex;
+  display: grid;
+  place-items: center;
   flex: 1 1 auto;
   width: 100%;
-  height: auto;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
   min-width: 0;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: auto !important;
+  height: 100% !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,21 @@ import { Toaster } from './components/ui/sonner';
 
 
 // Icons
-import { Plus, ChevronDown, ChevronRight, Replace, School, BookOpen, Music, ChevronLeft, Eye, Download, LayoutTemplate, BookMarked, Clock } from 'lucide-react';
+import {
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  Replace,
+  School,
+  BookOpen,
+  Music,
+  ChevronLeft,
+  Eye,
+  Download,
+  LayoutTemplate,
+  BookMarked,
+  Clock
+} from 'lucide-react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 const API = `${BACKEND_URL}/api`;
@@ -1261,8 +1275,6 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   </Button>
 
                                   <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                 
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
                                       className="rhyme-svg-content"
@@ -1297,8 +1309,6 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     </Button>
 
                                     <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                   
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
                                         className="rhyme-svg-content"


### PR DESCRIPTION
## Summary
- center rhyme preview containers with CSS grid so the SVG canvas can use the full vertical space
- force embedded rhyme SVGs to scale to both width and height to avoid cropping on larger desktop viewports

## Testing
- npm install --legacy-peer-deps *(fails: 403 Forbidden fetching @craco/craco from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68d76d18c3d883258f08f6d09aabd728