### PR TITLE
Refine rhyme preview A4 layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,35 +133,39 @@ body {
 }
 
 .a4-preview {
-  width: min(100%, 210mm);
+  width: clamp(280px, 70vw, 820px);
   aspect-ratio: 210 / 297;
-  max-height: min(calc(100vh - 160px), 297mm);
+  max-height: min(calc(100vh - 160px), 1120px);
+  background: #fff;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 34px 70px -30px rgba(15, 23, 42, 0.35);
 }
 
 @media (max-width: 1024px) {
   .a4-preview {
-    max-height: min(calc(100vh - 120px), 297mm);
+    max-height: min(calc(100vh - 120px), 960px);
+    border-radius: 24px;
   }
 }
 
 .rhyme-svg-content {
   position: relative;
-  display: flex;
+  display: grid;
+  place-items: stretch;
   flex: 1 1 auto;
   width: 100%;
-  height: auto;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
   min-width: 0;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: auto !important;
+  height: 100% !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
@@ -170,11 +174,24 @@ body {
 
 .rhyme-slot {
   width: 100%;
+  padding: clamp(20px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
 }
 
 .rhyme-slot-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
   width: 100%;
-  height: 100%;
+  min-height: 0;
+  padding: clamp(12px, 2.5vw, 22px);
+  border-radius: clamp(18px, 3vw, 26px);
+  background: linear-gradient(145deg, #f8fafc, #e2e8f0);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  overflow: hidden;
 }
 
 /* Button enhancements */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,21 @@ import { Toaster } from './components/ui/sonner';
 
 
 // Icons
-import { Plus, ChevronDown, ChevronRight, Replace, School, BookOpen, Music, ChevronLeft, Eye, Download, LayoutTemplate, BookMarked, Clock } from 'lucide-react';
+import {
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  Replace,
+  School,
+  BookOpen,
+  Music,
+  ChevronLeft,
+  Eye,
+  Download,
+  LayoutTemplate,
+  BookMarked,
+  Clock
+} from 'lucide-react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 const API = `${BACKEND_URL}/api`;
@@ -1239,15 +1253,13 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                   <div className="flex-1 min-h-0 py-4">
                     <div className="flex h-full items-center justify-center">
                       <div className="relative flex w-full justify-center">
-                        <div className="a4-preview relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                        <div className="a4-preview relative flex w-full flex-col overflow-hidden">
                           {showBottomContainer && (
                             <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                           )}
                           <div className="flex h-full flex-col">
                             <div
-                              className={`relative flex w-full flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 ${
-                                showBottomContainer ? 'border-b border-gray-200' : ''
-                              } rhyme-slot`}
+                              className="relative flex w-full flex-1 min-h-0 flex-col rhyme-slot"
                             >
                               {hasTopRhyme ? (
                                 <div className="relative flex flex-1 min-h-0 flex-col">
@@ -1260,9 +1272,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     Replace
                                   </Button>
 
-                                  <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                 
+                                  <div className="rhyme-slot-container">
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
                                       className="rhyme-svg-content"
@@ -1270,20 +1280,22 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   </div>
                                 </div>
                               ) : (
-                                <div className="flex flex-1 items-center justify-center">
-                                  <Button
-                                    onClick={() => handleAddRhyme('top')}
-                                    className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
-                                  >
-                                    <Plus className="h-8 w-8" />
-                                  </Button>
+                                <div className="rhyme-slot-container">
+                                  <div className="flex flex-1 items-center justify-center">
+                                    <Button
+                                      onClick={() => handleAddRhyme('top')}
+                                      className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
+                                    >
+                                      <Plus className="h-8 w-8" />
+                                    </Button>
+                                  </div>
                                 </div>
                               )}
                             </div>
 
                             {showBottomContainer && (
 
-                              <div className="relative flex w-full flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 rhyme-slot">
+                              <div className="relative flex w-full flex-1 min-h-0 flex-col rhyme-slot">
 
                                 {hasBottomRhyme ? (
                                   <div className="relative flex flex-1 min-h-0 flex-col">
@@ -1296,9 +1308,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       Replace
                                     </Button>
 
-                                    <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                   
+                                    <div className="rhyme-slot-container">
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
                                         className="rhyme-svg-content"
@@ -1306,13 +1316,15 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     </div>
                                   </div>
                                 ) : (
-                                  <div className="flex flex-1 items-center justify-center">
-                                    <Button
-                                      onClick={() => handleAddRhyme('bottom')}
-                                      className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
-                                    >
-                                      <Plus className="h-8 w-8" />
-                                    </Button>
+                                  <div className="rhyme-slot-container">
+                                    <div className="flex flex-1 items-center justify-center">
+                                      <Button
+                                        onClick={() => handleAddRhyme('bottom')}
+                                        className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
+                                      >
+                                        <Plus className="h-8 w-8" />
+                                      </Button>
+                                    </div>
                                   </div>
                                 )}
                               </div>


### PR DESCRIPTION
## Summary
- restyled the rhyme carousel wrapper so the preview frame more closely matches an A4 page with consistent proportions
- ensured the rhyme SVG slots stretch edge-to-edge inside the frame so the top and bottom halves each fill their side of the layout

## Testing
- node --check frontend/src/App.js

------
https://chatgpt.com/codex/tasks/task_b_68d76d18c3d883258f08f6d09aabd728