### PR TITLE
Refine rhyme preview sizing and menu transitions

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,48 +133,92 @@ body {
 }
 
 .a4-preview {
-  width: min(100%, 210mm);
-  aspect-ratio: 210 / 297;
-  max-height: min(calc(100vh - 160px), 297mm);
+  width: clamp(260px, 58vw, 720px);
+  height: min(calc(100vh - 140px), 980px);
+  background: #fff;
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 34px 70px -30px rgba(15, 23, 42, 0.35);
+  transition: width 0.4s ease, height 0.4s ease, box-shadow 0.4s ease;
 }
 
 @media (max-width: 1024px) {
   .a4-preview {
-    max-height: min(calc(100vh - 120px), 297mm);
+    width: clamp(240px, 75vw, 560px);
+    height: min(calc(100vh - 120px), 900px);
+    border-radius: 24px;
   }
+}
+
+@media (max-width: 640px) {
+  .a4-preview {
+    width: 100%;
+    height: auto;
+    min-height: 540px;
+  }
+}
+
+.rhyme-page-grid {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  gap: clamp(12px, 2.4vw, 24px);
+}
+
+.rhyme-slot {
+  width: 100%;
+  flex: 1 1 50%;
+  min-height: 0;
+  padding: clamp(18px, 3.6vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2.8vw, 22px);
+}
+
+.rhyme-slot-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  padding: clamp(14px, 2.2vw, 24px);
+  border-radius: clamp(18px, 3vw, 26px);
+  background: linear-gradient(145deg, #f8fafc, #e2e8f0);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.rhyme-slot-container:hover {
+  transform: translateY(-2px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 24px -16px rgba(15, 23, 42, 0.4);
 }
 
 .rhyme-svg-content {
   position: relative;
   display: flex;
+  align-items: center;
+  justify-content: center;
   flex: 1 1 auto;
   width: 100%;
-  height: auto;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
   min-width: 0;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
+  padding: clamp(6px, 1.5vw, 12px);
 }
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: auto !important;
-  max-width: 100%;
-  max-height: 100%;
+  height: 100% !important;
+  max-width: none;
+  max-height: none;
   object-fit: contain;
   display: block;
-}
-
-.rhyme-slot {
-  width: 100%;
-}
-
-.rhyme-slot-container {
-  width: 100%;
-  height: 100%;
 }
 
 /* Button enhancements */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,21 @@ import { Toaster } from './components/ui/sonner';
 
 
 // Icons
-import { Plus, ChevronDown, ChevronRight, Replace, School, BookOpen, Music, ChevronLeft, Eye, Download, LayoutTemplate, BookMarked, Clock } from 'lucide-react';
+import {
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  Replace,
+  School,
+  BookOpen,
+  Music,
+  ChevronLeft,
+  Eye,
+  Download,
+  LayoutTemplate,
+  BookMarked,
+  Clock
+} from 'lucide-react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 const API = `${BACKEND_URL}/api`;
@@ -1238,16 +1252,14 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 py-4">
                     <div className="flex h-full items-center justify-center">
-                      <div className="relative flex w-full justify-center">
-                        <div className="a4-preview relative flex w-full flex-col overflow-hidden rounded-[32px] border border-gray-300 bg-gradient-to-b from-white to-gray-50 shadow-2xl">
+                      <div className="relative flex w-full justify-center transition-all duration-300 ease-out">
+                        <div className="a4-preview relative flex w-full flex-col overflow-hidden">
                           {showBottomContainer && (
                             <div className="pointer-events-none absolute inset-x-12 top-1/2 h-px bg-gradient-to-r from-transparent via-gray-300 to-transparent" />
                           )}
-                          <div className="flex h-full flex-col">
+                          <div className="rhyme-page-grid h-full">
                             <div
-                              className={`relative flex w-full flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 ${
-                                showBottomContainer ? 'border-b border-gray-200' : ''
-                              } rhyme-slot`}
+                              className="relative flex w-full min-h-0 flex-col rhyme-slot"
                             >
                               {hasTopRhyme ? (
                                 <div className="relative flex flex-1 min-h-0 flex-col">
@@ -1260,9 +1272,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     Replace
                                   </Button>
 
-                                  <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                 
+                                  <div className="rhyme-slot-container">
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
                                       className="rhyme-svg-content"
@@ -1270,20 +1280,22 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                   </div>
                                 </div>
                               ) : (
-                                <div className="flex flex-1 items-center justify-center">
-                                  <Button
-                                    onClick={() => handleAddRhyme('top')}
-                                    className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
-                                  >
-                                    <Plus className="h-8 w-8" />
-                                  </Button>
+                                <div className="rhyme-slot-container">
+                                  <div className="flex flex-1 items-center justify-center">
+                                    <Button
+                                      onClick={() => handleAddRhyme('top')}
+                                      className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
+                                    >
+                                      <Plus className="h-8 w-8" />
+                                    </Button>
+                                  </div>
                                 </div>
                               )}
                             </div>
 
                             {showBottomContainer && (
 
-                              <div className="relative flex w-full flex-1 min-h-0 flex-col p-4 sm:p-6 lg:p-8 rhyme-slot">
+                              <div className="relative flex w-full min-h-0 flex-col rhyme-slot">
 
                                 {hasBottomRhyme ? (
                                   <div className="relative flex flex-1 min-h-0 flex-col">
@@ -1296,9 +1308,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       Replace
                                     </Button>
 
-                                    <div className="rhyme-slot-container flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-xl bg-gray-50 p-3 sm:p-4">
-=======
-                                   
+                                    <div className="rhyme-slot-container">
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}
                                         className="rhyme-svg-content"
@@ -1306,13 +1316,15 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     </div>
                                   </div>
                                 ) : (
-                                  <div className="flex flex-1 items-center justify-center">
-                                    <Button
-                                      onClick={() => handleAddRhyme('bottom')}
-                                      className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
-                                    >
-                                      <Plus className="h-8 w-8" />
-                                    </Button>
+                                  <div className="rhyme-slot-container">
+                                    <div className="flex flex-1 items-center justify-center">
+                                      <Button
+                                        onClick={() => handleAddRhyme('bottom')}
+                                        className="h-24 w-24 transform rounded-full bg-gradient-to-r from-orange-400 to-red-400 text-white shadow-lg transition-all duration-300 hover:scale-105 hover:from-orange-500 hover:to-red-500 hover:shadow-xl"
+                                      >
+                                        <Plus className="h-8 w-8" />
+                                      </Button>
+                                    </div>
                                   </div>
                                 )}
                               </div>
@@ -1325,38 +1337,46 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 </div>
               </div>
             </div>
-            {showTreeMenu && (
-              <div className="absolute inset-0 z-40 flex">
-                <div className="relative flex h-full w-full max-w-md min-h-0 flex-col overflow-hidden bg-white/95 backdrop-blur shadow-2xl sm:max-w-lg lg:max-w-sm lg:rounded-r-3xl lg:border lg:border-gray-200">
-                  <div className="flex-shrink-0 p-4 sm:p-5 lg:p-6">
-                    <Button
-                      onClick={() => { setShowTreeMenu(false); setCurrentPosition(null); }}
-                      variant="outline"
-                      className="w-full"
-                    >
-                      <ChevronLeft className="w-4 h-4 mr-2" />
-                      Close Menu
-                    </Button>
-                  </div>
-                  <div className="flex-1 min-h-0 overflow-hidden px-2 pb-4 sm:px-4">
-                    <TreeMenu
-                      rhymesData={availableRhymes}
-                      reusableRhymes={reusableRhymes}
-                      showReusable={showReusable}
-                      onRhymeSelect={handleRhymeSelect}
-                      onToggleReusable={handleToggleReusable}
-                      hideFullPageRhymes={currentPosition === 'bottom'}
-                    />
-                  </div>
+            <div
+              className={`absolute inset-0 z-40 flex transition-opacity duration-300 ease-out ${
+                showTreeMenu ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+              }`}
+            >
+              <div
+                className={`relative flex h-full w-full max-w-md min-h-0 flex-col overflow-hidden bg-white/95 backdrop-blur shadow-2xl sm:max-w-lg lg:max-w-sm lg:rounded-r-3xl lg:border lg:border-gray-200 transition-transform duration-300 ease-out ${
+                  showTreeMenu ? 'translate-x-0' : '-translate-x-full'
+                }`}
+              >
+                <div className="flex-shrink-0 p-4 sm:p-5 lg:p-6">
+                  <Button
+                    onClick={() => { setShowTreeMenu(false); setCurrentPosition(null); }}
+                    variant="outline"
+                    className="w-full"
+                  >
+                    <ChevronLeft className="w-4 h-4 mr-2" />
+                    Close Menu
+                  </Button>
                 </div>
-                <button
-                  type="button"
-                  className="flex-1 bg-black/30 backdrop-blur-sm"
-                  aria-label="Close tree menu overlay"
-                  onClick={() => { setShowTreeMenu(false); setCurrentPosition(null); }}
-                />
+                <div className="flex-1 min-h-0 overflow-hidden px-2 pb-4 sm:px-4">
+                  <TreeMenu
+                    rhymesData={availableRhymes}
+                    reusableRhymes={reusableRhymes}
+                    showReusable={showReusable}
+                    onRhymeSelect={handleRhymeSelect}
+                    onToggleReusable={handleToggleReusable}
+                    hideFullPageRhymes={currentPosition === 'bottom'}
+                  />
+                </div>
               </div>
-            )}
+              <button
+                type="button"
+                className={`flex-1 bg-black/30 backdrop-blur-sm transition-opacity duration-300 ease-out ${
+                  showTreeMenu ? 'opacity-100' : 'opacity-0'
+                }`}
+                aria-label="Close tree menu overlay"
+                onClick={() => { setShowTreeMenu(false); setCurrentPosition(null); }}
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- narrow the A4 preview frame and rebalance the rhyme slot styling so each half of the page stretches evenly while SVGs scale cleanly at full width
- add smooth transition effects to the preview container, rhyme slot cards, and the slide-out tree menu for a gentler layout update experience

## Testing
- node --check frontend/src/App.js
- npm install --legacy-peer-deps *(fails: 403 Forbidden fetching @craco/craco)*

------
https://chatgpt.com/codex/tasks/task_b_68d76d18c3d883258f08f6d09aabd728