### PR TITLE
Adjust rhyme SVG sizing for desktop

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -204,17 +204,11 @@ body {
 
 .rhyme-svg-content {
   position: relative;
-
   display: flex;
-  
-=======
-  display: grid;
-
-  place-items: stretch;
-
+  align-items: center;
+  justify-content: center;
   flex: 1 1 auto;
   width: 100%;
-  height: 100%;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
@@ -225,17 +219,12 @@ body {
 
 .rhyme-svg-content svg {
   width: 100% !important;
-  height: 100% !important;
-
-  max-width: none;
-  max-height: none;
-
-
+  height: auto !important;
+  max-height: 100%;
   object-fit: contain;
   display: block;
 }
 
-\
 /* Button enhancements */
 .btn-gradient {
   background: linear-gradient(135deg, #fb923c, #ef4444);


### PR DESCRIPTION
## Summary
- center the rhyme SVG container with flex layout so content can expand fully
- scale rhyme SVGs to use the full slot width while maintaining their aspect ratio on desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d78a4e7c788325a1883a29335a8366