### PR TITLE
Adjust desktop layout for rhyme slots

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -195,6 +195,8 @@ body {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
   overflow: hidden;
   transition: transform 0.35s ease, box-shadow 0.35s ease;
+  justify-content: center;
+  align-items: center;
 }
 
 .rhyme-slot-container:hover {
@@ -223,6 +225,26 @@ body {
   max-height: 100%;
   object-fit: contain;
   display: block;
+}
+
+@media (min-width: 1024px) {
+  .rhyme-page-grid {
+    align-items: center;
+  }
+
+  .rhyme-slot {
+    align-items: center;
+  }
+
+  .rhyme-slot-container {
+    max-width: clamp(420px, 42vw, 560px);
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .rhyme-svg-content {
+    max-width: 100%;
+  }
 }
 
 /* Button enhancements */


### PR DESCRIPTION
## Summary
- center rhyme slot containers and SVG content so they mirror the mobile presentation
- limit desktop rhyme slot width and align the slots to improve consistency across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d78e5557088325ae02b0c359b64cac