### PR TITLE
Ensure rhyme slot children fill available space

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -182,6 +182,15 @@ body {
   gap: clamp(14px, 2.8vw, 22px);
 }
 
+.rhyme-slot > .relative {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .rhyme-slot-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure the inner relative container inside each rhyme slot stretches to fill the available space
- enforce full-width and full-height flex layout so rhyme content can occupy the parent slot without collapsing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7ad897b9483258b8eb4941a5f0890