### PR TITLE
Adjust rhyme SVG container layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -215,9 +215,7 @@ body {
 
 .rhyme-svg-content {
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   flex: 1 1 auto;
   width: 100%;
   max-width: 100%;
@@ -226,6 +224,7 @@ body {
   min-width: 0;
   overflow: hidden;
   padding: clamp(6px, 1.5vw, 12px);
+  line-height: 0;
 }
 
 .rhyme-svg-content svg {


### PR DESCRIPTION
## Summary
- stop centering rhyme SVG containers so artwork can stretch across the full slot width
- switch the container to block layout with zero line-height while preserving responsive SVG scaling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d7af8748ec83259fee13c38200b8d4