### PR TITLE
Adjust rhyme slot layout to remove SVG padding

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -208,6 +208,11 @@ body {
   align-items: center;
 }
 
+.rhyme-slot-container.has-svg {
+  padding: 0;
+  align-items: stretch;
+}
+
 .rhyme-slot-container:hover {
   transform: translateY(-2px);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 24px -16px rgba(15, 23, 42, 0.4);
@@ -227,12 +232,22 @@ body {
   line-height: 0;
 }
 
+.rhyme-slot-container.has-svg .rhyme-svg-content {
+  padding: 0;
+  display: flex;
+}
+
 .rhyme-svg-content svg {
   width: 100% !important;
   height: auto !important;
   max-height: 100%;
   object-fit: contain;
   display: block;
+}
+
+.rhyme-slot-container.has-svg .rhyme-svg-content svg {
+  height: 100% !important;
+  flex: 1 1 auto;
 }
 
 @media (min-width: 1024px) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1276,7 +1276,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     Replace
                                   </Button>
 
-                                  <div className="rhyme-slot-container">
+                                  <div className={`rhyme-slot-container${hasTopRhyme ? ' has-svg' : ''}`}>
 
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
@@ -1314,7 +1314,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       Replace
                                     </Button>
 
-                                    <div className="rhyme-slot-container">
+                                    <div className={`rhyme-slot-container${hasBottomRhyme ? ' has-svg' : ''}`}>
 
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}


### PR DESCRIPTION
## Summary
- add a `has-svg` modifier class when a rhyme slot has SVG content
- update rhyme slot container styling so SVG content can stretch to the edges without padding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7b182a4008325a79a9c27ca9216bd