### PR TITLE
Stretch SVG rects to fill rhyme container

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -208,6 +208,11 @@ body {
   align-items: center;
 }
 
+.rhyme-slot-container.has-svg {
+  padding: 0;
+  align-items: stretch;
+}
+
 .rhyme-slot-container:hover {
   transform: translateY(-2px);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 24px -16px rgba(15, 23, 42, 0.4);
@@ -218,6 +223,7 @@ body {
   display: block;
   flex: 1 1 auto;
   width: 100%;
+  height: 100%;
   max-width: 100%;
   max-height: 100%;
   min-height: 0;
@@ -227,12 +233,22 @@ body {
   line-height: 0;
 }
 
+.rhyme-slot-container.has-svg .rhyme-svg-content {
+  padding: 0;
+  display: flex;
+}
+
 .rhyme-svg-content svg {
   width: 100% !important;
   height: auto !important;
   max-height: 100%;
   object-fit: contain;
   display: block;
+}
+
+.rhyme-slot-container.has-svg .rhyme-svg-content svg {
+  height: 100% !important;
+  flex: 1 1 auto;
 }
 
 @media (min-width: 1024px) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -62,14 +62,13 @@ const sanitizeRhymeSvgContent = (svgContent, rhymeCode) => {
 
     const widthAttr = svgElement.getAttribute('width');
     const heightAttr = svgElement.getAttribute('height');
+    const widthValue = Number.parseFloat(widthAttr ?? '');
+    const heightValue = Number.parseFloat(heightAttr ?? '');
 
     svgElement.removeAttribute('width');
     svgElement.removeAttribute('height');
 
     if (!svgElement.getAttribute('viewBox')) {
-      const widthValue = parseFloat(widthAttr ?? '');
-      const heightValue = parseFloat(heightAttr ?? '');
-
       if (Number.isFinite(widthValue) && Number.isFinite(heightValue) && widthValue > 0 && heightValue > 0) {
         svgElement.setAttribute('viewBox', `0 0 ${widthValue} ${heightValue}`);
       }
@@ -77,6 +76,79 @@ const sanitizeRhymeSvgContent = (svgContent, rhymeCode) => {
 
     if (!svgElement.getAttribute('preserveAspectRatio')) {
       svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    }
+
+    const viewBoxAttr = svgElement.getAttribute('viewBox');
+    let viewBoxWidth;
+    let viewBoxHeight;
+
+    if (typeof viewBoxAttr === 'string' && viewBoxAttr.trim().length > 0) {
+      const viewBoxParts = viewBoxAttr
+        .trim()
+        .split(/[\s,]+/)
+        .map((part) => Number.parseFloat(part))
+        .filter((part) => Number.isFinite(part));
+
+      if (viewBoxParts.length >= 4) {
+        viewBoxWidth = viewBoxParts[2];
+        viewBoxHeight = viewBoxParts[3];
+      }
+    }
+
+    const targetWidth = Number.isFinite(viewBoxWidth) ? viewBoxWidth : widthValue;
+    const targetHeight = Number.isFinite(viewBoxHeight) ? viewBoxHeight : heightValue;
+
+    if (Number.isFinite(targetWidth) && Number.isFinite(targetHeight)) {
+      const rectElements = svgElement.querySelectorAll('rect');
+
+      rectElements.forEach((rect) => {
+        const rectWidthAttr = rect.getAttribute('width');
+        const rectHeightAttr = rect.getAttribute('height');
+        const rectWidthValue = Number.parseFloat(rectWidthAttr ?? '');
+        const rectHeightValue = Number.parseFloat(rectHeightAttr ?? '');
+        const rectXAttr = rect.getAttribute('x');
+        const rectYAttr = rect.getAttribute('y');
+        const rectXValue = Number.parseFloat(rectXAttr ?? '');
+        const rectYValue = Number.parseFloat(rectYAttr ?? '');
+
+        const rectWidthMatchesSvg =
+          Number.isFinite(widthValue) && Number.isFinite(rectWidthValue) && Math.abs(rectWidthValue - widthValue) < 0.5;
+        const rectHeightMatchesSvg =
+          Number.isFinite(heightValue) && Number.isFinite(rectHeightValue) && Math.abs(rectHeightValue - heightValue) < 0.5;
+
+        const rectWidthNeedsUpdate =
+          !rectWidthAttr ||
+          /%/i.test(rectWidthAttr) ||
+          !Number.isFinite(rectWidthValue) ||
+          rectWidthMatchesSvg;
+
+        const rectHeightNeedsUpdate =
+          !rectHeightAttr ||
+          /%/i.test(rectHeightAttr) ||
+          !Number.isFinite(rectHeightValue) ||
+          rectHeightMatchesSvg;
+
+        const rectXNeedsUpdate =
+          rectWidthNeedsUpdate && (!rectXAttr || !Number.isFinite(rectXValue) || Math.abs(rectXValue) < 0.5);
+        const rectYNeedsUpdate =
+          rectHeightNeedsUpdate && (!rectYAttr || !Number.isFinite(rectYValue) || Math.abs(rectYValue) < 0.5);
+
+        if (rectWidthNeedsUpdate) {
+          rect.setAttribute('width', '100%');
+        }
+
+        if (rectHeightNeedsUpdate) {
+          rect.setAttribute('height', '100%');
+        }
+
+        if (rectXNeedsUpdate) {
+          rect.setAttribute('x', '0');
+        }
+
+        if (rectYNeedsUpdate) {
+          rect.setAttribute('y', '0');
+        }
+      });
     }
 
     const normalizedCode = (rhymeCode ?? '').toString().trim();
@@ -1276,7 +1348,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                     Replace
                                   </Button>
 
-                                  <div className="rhyme-slot-container">
+                                  <div className={`rhyme-slot-container${hasTopRhyme ? ' has-svg' : ''}`}>
 
                                     <div
                                       dangerouslySetInnerHTML={{ __html: currentPageRhymes.top.svgContent || '' }}
@@ -1314,7 +1386,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                                       Replace
                                     </Button>
 
-                                    <div className="rhyme-slot-container">
+                                    <div className={`rhyme-slot-container${hasBottomRhyme ? ' has-svg' : ''}`}>
 
                                       <div
                                         dangerouslySetInnerHTML={{ __html: currentPageRhymes.bottom.svgContent || '' }}


### PR DESCRIPTION
## Summary
- ensure sanitized SVG rects expand to the full viewport by setting width and height to 100%
- realign rect origins to remove offsets so artwork meets the container edges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7b182a4008325a79a9c27ca9216bd