### PR TITLE
Add double-page rhyme support and menu grouping

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -182,6 +182,10 @@ body {
   gap: clamp(14px, 2.8vw, 22px);
 }
 
+.double-page-slot {
+  flex: 1 1 auto;
+}
+
 .rhyme-slot > .relative {
   flex: 1 1 auto;
   min-height: 0;
@@ -220,6 +224,13 @@ body {
   display: flex;
 }
 
+.rhyme-slot-container.double-page {
+  flex-direction: column;
+  background: linear-gradient(160deg, #f8fafc 0%, #e0f2fe 100%);
+  border: 1px solid rgba(14, 116, 144, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 36px -24px rgba(14, 116, 144, 0.4);
+}
+
 .rhyme-slot-container:hover {
   transform: translateY(-2px);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 14px 24px -16px rgba(15, 23, 42, 0.4);
@@ -246,6 +257,47 @@ body {
   padding: 0;
   display: flex;
   align-items: stretch;
+  justify-content: center;
+}
+
+.double-page-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.double-page-pane {
+  flex: 1 1 50%;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2.2vw, 18px);
+  padding: clamp(12px, 2vw, 20px);
+  background: rgba(255, 255, 255, 0.88);
+  position: relative;
+}
+
+.double-page-pane-header {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.double-page-badge {
+  background: rgba(14, 116, 144, 0.12);
+  color: #0f172a;
+  border-radius: 9999px;
+  font-weight: 600;
+}
+
+.double-page-divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, rgba(15, 23, 42, 0.18), transparent);
+}
+
+.double-page-fallback {
+  align-items: center;
   justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- add sorted tree menu grouping with a dedicated "Page 2.0 Rhymes" category
- support double-page rhymes by mirroring their SVG into a split preview with 1.0 page badges
- style the combined double-page container for a clear horizontal split display

## Testing
- `npm test -- --watchAll=false` *(fails: sh: 1: craco: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d7df9be298832585de82553c29ba5b