### PR TITLE
Add backend cover asset manifest endpoint and defaults

### DIFF
--- a/frontend/src/components/CoverPageWorkflow.jsx
+++ b/frontend/src/components/CoverPageWorkflow.jsx
@@ -339,8 +339,10 @@ const applyPersonalisationToSvg = (svgMarkup, personalisation) => {
  }
    
 const CoverPageWorkflow = ({ school, grade, onBackToGrades, onBackToMode, onLogout }) => {
-  const manifestUrl = process.env.REACT_APP_COVER_ASSETS_MANIFEST_URL;
-  const baseAssetsUrl = process.env.REACT_APP_COVER_ASSETS_BASE_URL;
+  const manifestUrl =
+    process.env.REACT_APP_COVER_ASSETS_MANIFEST_URL || '/api/cover-assets/manifest';
+  const baseAssetsUrl =
+    process.env.REACT_APP_COVER_ASSETS_BASE_URL || '/api/cover-assets/svg';
 
   const [manifestLoading, setManifestLoading] = useState(false);
   const [manifestError, setManifestError] = useState('');


### PR DESCRIPTION
## Summary
- expose an API that builds a manifest of cover SVG files from the configured COVER_SVG_BASE_PATH and streams the raw assets
- surface clearer HTTP errors when the cover asset path is missing or invalid
- point the cover workflow UI at the new manifest endpoint by default so assets load without extra configuration

## Testing
- pytest *(fails: missing requests dependency in test harness)*

------
https://chatgpt.com/codex/tasks/task_b_68da756b59088325b3275214ccc17997