### PR TITLE
Refine rhyme SVG loading helper and extend binder tests

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -152,6 +152,28 @@ def generate_rhyme_svg(rhyme_code: str) -> str:
     """
 
 
+def _load_rhyme_svg_markup(rhyme_code: str) -> str:
+    """Return SVG markup for ``rhyme_code``.
+
+    When a filesystem base path is configured the function prefers loading the
+    authored SVG asset so the generated PDF binder can embed the authentic
+    artwork. If the asset is missing the helper falls back to
+    :func:`generate_rhyme_svg`.
+    """
+
+    if RHYME_SVG_BASE_PATH is not None:
+        svg_path = RHYME_SVG_BASE_PATH / f"{rhyme_code}.svg"
+
+        try:
+            return svg_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            logger.warning("SVG file not found for rhyme %s at %s", rhyme_code, svg_path)
+        except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
+            logger.error("Unable to read SVG for rhyme %s at %s: %s", rhyme_code, svg_path, exc)
+
+    return generate_rhyme_svg(rhyme_code)
+
+
 def _parse_csv(value: Optional[str], *, default: Optional[List[str]] = None) -> List[str]:
     """Return a normalized list from a comma separated string."""
 
@@ -746,25 +768,10 @@ async def get_rhyme_svg(rhyme_code: str):
     the frontend continues to work for missing assets.
     """
 
-    svg_content: Optional[str] = None
-
-    if RHYME_SVG_BASE_PATH is not None:
-        # svg_path = RHYME_SVG_BASE_PATH / f"{rhyme_code}.svg"
-        svg_path= Path(r"\\pixartnas\home\RHYMES & STORIES\NEW\Rhymes\SVGs") / f"{rhyme_code}.svg"
-        print(svg_path)
-        try:
-            svg_content = svg_path.read_text(encoding="utf-8")
-            
-        except FileNotFoundError:
-            logger.warning("SVG file not found for rhyme %s at %s", rhyme_code, svg_path)
-        except OSError as exc:
-            logger.error("Unable to read SVG for rhyme %s at %s: %s", rhyme_code, svg_path, exc)
-
-    if svg_content is None:
-        try:
-            svg_content = generate_rhyme_svg(rhyme_code)
-        except KeyError:
-            raise HTTPException(status_code=404, detail="Rhyme not found")
+    try:
+        svg_content = _load_rhyme_svg_markup(rhyme_code)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Rhyme not found")
 
     return Response(content=svg_content, media_type="image/svg+xml")
 
@@ -1021,7 +1028,7 @@ async def download_rhyme_binder(school_id: str, grade: str):
 
         if full_page_entry:
             try:
-                svg_markup = generate_rhyme_svg(full_page_entry["rhyme_code"])
+                svg_markup = _load_rhyme_svg_markup(full_page_entry["rhyme_code"])
             except KeyError:
                 svg_markup = None
 
@@ -1059,7 +1066,7 @@ async def download_rhyme_binder(school_id: str, grade: str):
                 svg_rendered = False
 
                 try:
-                    svg_markup = generate_rhyme_svg(entry["rhyme_code"])
+                    svg_markup = _load_rhyme_svg_markup(entry["rhyme_code"])
                 except KeyError:
                     svg_markup = None
 

--- a/tests/test_rhyme_svg_loader.py
+++ b/tests/test_rhyme_svg_loader.py
@@ -1,0 +1,291 @@
+import asyncio
+import os
+import sys
+import types
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for optional dependencies so ``backend.server`` can be imported
+# without installing the real FastAPI stack inside the execution environment.
+# ---------------------------------------------------------------------------
+
+os.environ.setdefault("MONGO_URL", "mongodb://localhost")
+os.environ.setdefault("DB_NAME", "testdb")
+
+
+class _HTTPException(Exception):
+    def __init__(self, status_code: int, detail=None):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class _Response:
+    def __init__(self, content=b"", media_type: str | None = None, headers: dict | None = None):
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.body = content
+        self.media_type = media_type
+        self.headers = headers or {}
+        self.status_code = 200
+
+
+class _APIRouter:
+    def __init__(self, prefix: str = ""):
+        self.prefix = prefix
+
+    def _decorator(self, func):
+        return func
+
+    def get(self, *_, **__):
+        return self._decorator
+
+    def post(self, *_, **__):
+        return self._decorator
+
+    def delete(self, *_, **__):
+        return self._decorator
+
+
+class _FastAPI:
+    def add_middleware(self, *_, **__):  # pragma: no cover - invoked during import
+        return None
+
+    def include_router(self, *_):  # pragma: no cover - invoked during import
+        return None
+
+    def on_event(self, *_args, **__):  # pragma: no cover - decorator shim
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+fastapi_module = types.ModuleType("fastapi")
+fastapi_module.FastAPI = _FastAPI
+fastapi_module.APIRouter = _APIRouter
+fastapi_module.HTTPException = _HTTPException
+
+responses_module = types.ModuleType("fastapi.responses")
+responses_module.Response = _Response
+
+fastapi_module.responses = responses_module
+
+sys.modules.setdefault("fastapi", fastapi_module)
+sys.modules.setdefault("fastapi.responses", responses_module)
+
+
+dotenv_module = types.ModuleType("dotenv")
+
+
+def _load_dotenv(*_, **__):  # pragma: no cover - behaviour not exercised
+    return None
+
+
+dotenv_module.load_dotenv = _load_dotenv
+sys.modules.setdefault("dotenv", dotenv_module)
+
+
+cors_module = types.ModuleType("starlette.middleware.cors")
+
+
+class _CORSMiddleware:  # pragma: no cover - used for dependency injection only
+    def __init__(self, *_, **__):
+        pass
+
+
+cors_module.CORSMiddleware = _CORSMiddleware
+sys.modules.setdefault("starlette.middleware.cors", cors_module)
+
+
+motor_module = types.ModuleType("motor")
+motor_asyncio_module = types.ModuleType("motor.motor_asyncio")
+
+
+class _AsyncIOMotorClient:
+    def __init__(self, *_, **__):
+        self._databases: dict[str, SimpleNamespace] = {}
+
+    def __getitem__(self, name: str) -> SimpleNamespace:
+        return self._databases.setdefault(name, SimpleNamespace())
+
+
+motor_asyncio_module.AsyncIOMotorClient = _AsyncIOMotorClient
+motor_module.motor_asyncio = motor_asyncio_module
+sys.modules.setdefault("motor", motor_module)
+sys.modules.setdefault("motor.motor_asyncio", motor_asyncio_module)
+
+
+pydantic_module = types.ModuleType("pydantic")
+
+
+class _BaseModel:
+    def __init__(self, **data):
+        for key, value in data.items():
+            setattr(self, key, value)
+
+    def dict(self):  # pragma: no cover - helper for API code paths
+        return dict(self.__dict__)
+
+
+def _Field(default=None, default_factory=None, **_):
+    if default_factory is not None:
+        return default_factory()
+    return default
+
+
+pydantic_module.BaseModel = _BaseModel
+pydantic_module.Field = _Field
+sys.modules.setdefault("pydantic", pydantic_module)
+
+
+from backend import server
+
+
+class DummyCanvas:
+    """Minimal canvas stub used by binder tests."""
+
+    def __init__(self, buffer: BytesIO, pagesize):
+        self.buffer = buffer
+        self.pagesize = pagesize
+        self.pages = 0
+
+    def showPage(self) -> None:  # pragma: no cover - trivial
+        self.pages += 1
+
+    def save(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class DummyCursor:
+    def __init__(self, data):
+        self._data = data
+
+    async def to_list(self, _):
+        return list(self._data)
+
+
+class DummyCollection:
+    def __init__(self, data):
+        self._data = data
+
+    def find(self, query):  # pragma: no cover - data is static
+        return DummyCursor(self._data)
+
+
+@pytest.fixture
+def stub_pdf_resources(monkeypatch):
+    resources = SimpleNamespace(
+        canvas_factory=lambda buffer, pagesize: DummyCanvas(buffer, pagesize),
+        page_size=(400.0, 300.0),
+        svg_backend=server._SvgBackend("none", None, None, None, None),
+    )
+    monkeypatch.setattr(server, "_load_pdf_dependencies", lambda: resources)
+    return resources
+
+
+@pytest.fixture
+def stub_db(monkeypatch):
+    collection = DummyCollection([])
+    monkeypatch.setattr(
+        server,
+        "db",
+        SimpleNamespace(rhyme_selections=collection),
+    )
+    return collection
+
+
+def test_binder_uses_external_svg(tmp_path, monkeypatch, stub_pdf_resources, stub_db):
+    rhyme_code = "RX001"
+    svg_content = "<svg>real</svg>"
+    (tmp_path / f"{rhyme_code}.svg").write_text(svg_content, encoding="utf-8")
+
+    stub_db._data = [
+        {
+            "page_index": 0,
+            "rhyme_code": rhyme_code,
+            "pages": 1.0,
+            "position": "top",
+        }
+    ]
+
+    monkeypatch.setattr(server, "RHYME_SVG_BASE_PATH", tmp_path)
+    monkeypatch.setattr(
+        server,
+        "RHYMES_DATA",
+        {rhyme_code: ("Test rhyme", 1.0, False)},
+    )
+
+    captured = {}
+
+    def fake_render(pdf_canvas, backend, svg_markup, width, height, *, x=0, y=0):
+        captured["markup"] = svg_markup
+        captured["size"] = (width, height)
+        captured["position"] = (x, y)
+        return True
+
+    draw_calls = []
+
+    def fake_draw(pdf_canvas, entry, page_width, page_height, y_offset=0):
+        draw_calls.append(entry)
+
+    monkeypatch.setattr(server, "_render_svg_on_canvas", fake_render)
+    monkeypatch.setattr(server, "_draw_text_only_rhyme", fake_draw)
+
+    response = asyncio.run(server.download_rhyme_binder("school", "grade"))
+
+    assert response.media_type == "application/pdf"
+    assert captured["markup"] == svg_content
+    assert draw_calls == []
+
+
+def test_binder_falls_back_to_generated_svg(tmp_path, monkeypatch, stub_pdf_resources, stub_db):
+    rhyme_code = "RX002"
+    sentinel_svg = "<svg>generated</svg>"
+
+    stub_db._data = [
+        {
+            "page_index": 0,
+            "rhyme_code": rhyme_code,
+            "pages": 0.5,
+            "position": "top",
+        }
+    ]
+
+    monkeypatch.setattr(server, "RHYME_SVG_BASE_PATH", tmp_path)
+    monkeypatch.setattr(
+        server,
+        "RHYMES_DATA",
+        {rhyme_code: ("Test rhyme", 0.5, False)},
+    )
+
+    def fake_generate(code):
+        if code != rhyme_code:
+            raise KeyError(code)
+        return sentinel_svg
+
+    captured = {"markups": []}
+
+    def fake_render(pdf_canvas, backend, svg_markup, width, height, *, x=0, y=0):
+        captured["markups"].append(svg_markup)
+        return False
+
+    draw_calls = []
+
+    def fake_draw(pdf_canvas, entry, page_width, page_height, y_offset=0):
+        draw_calls.append({"entry": entry, "y_offset": y_offset})
+
+    monkeypatch.setattr(server, "generate_rhyme_svg", fake_generate)
+    monkeypatch.setattr(server, "_render_svg_on_canvas", fake_render)
+    monkeypatch.setattr(server, "_draw_text_only_rhyme", fake_draw)
+
+    response = asyncio.run(server.download_rhyme_binder("school", "grade"))
+
+    assert response.media_type == "application/pdf"
+    assert captured["markups"] == [sentinel_svg]
+    assert len(draw_calls) == 1
+    assert draw_calls[0]["entry"]["rhyme_code"] == rhyme_code


### PR DESCRIPTION
## Summary
- add a dedicated helper for loading rhyme SVG assets with a generated fallback and reuse it in the API
- ensure the binder export consumes authentic SVG markup when available before falling back to placeholders
- add unit tests with lightweight dependency stubs to cover both the real-asset and generated SVG code paths

## Testing
- pytest tests/test_rhyme_svg_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68dbc59808148325aba4c3a3419ef3d7