### PR TITLE
Ensure gradient sanitiser applies default fallbacks

### DIFF
--- a/backend/s1.py
+++ b/backend/s1.py
@@ -11,10 +11,12 @@ import json
 from pathlib import Path
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
-from typing import Callable, List, Dict, Optional, Any, Tuple, Literal
+from typing import Callable, List, Dict, Optional, Any, Tuple, Literal, Set
 from io import BytesIO
 from functools import lru_cache
 from urllib.parse import quote
+from xml.etree import ElementTree as ET
+import re
 
 import uuid
 from datetime import datetime
@@ -23,6 +25,10 @@ ROOT_DIR = Path(__file__).parent
 load_dotenv(ROOT_DIR / ".env")
 
 logger = logging.getLogger(__name__)
+
+SVG_NS = "http://www.w3.org/2000/svg"
+_GRADIENT_URL_RE = re.compile(r"^url\(#(?P<id>[^)]+)\)$")
+_DEFAULT_GRADIENT_FALLBACK_COLOR = "#000000"
 
 
 def _resolve_svg_base_path() -> Optional[Path]:
@@ -107,6 +113,151 @@ def _build_cover_asset_manifest(base_path: Path) -> List[Dict[str, str]]:
         )
 
     return assets
+
+
+def _parse_style_declarations(style: str) -> List[Tuple[str, str]]:
+    """Return the CSS declarations contained in ``style`` preserving order."""
+
+    declarations: List[Tuple[str, str]] = []
+    for raw_entry in style.split(";"):
+        if not raw_entry.strip():
+            continue
+
+        if ":" not in raw_entry:
+            continue
+
+        property_name, value = raw_entry.split(":", 1)
+        declarations.append((property_name.strip(), value.strip()))
+
+    return declarations
+
+
+def _serialize_style_declarations(declarations: List[Tuple[str, str]]) -> str:
+    """Serialize ``declarations`` back into an inline CSS string."""
+
+    return ";".join(f"{name}:{value}" for name, value in declarations)
+
+
+def _collect_gradient_fallback_colors(root: ET.Element) -> Tuple[Dict[str, str], Set[str]]:
+    """Return gradient colour fallbacks and the ids they apply to."""
+
+    gradient_colors: Dict[str, str] = {}
+    gradient_ids: Set[str] = set()
+    stop_xpath = f".//{{{SVG_NS}}}stop"
+
+    for gradient_tag in (
+        f".//{{{SVG_NS}}}linearGradient",
+        f".//{{{SVG_NS}}}radialGradient",
+    ):
+        for gradient in root.findall(gradient_tag):
+            gradient_id = gradient.attrib.get("id")
+            if not gradient_id:
+                continue
+
+            gradient_ids.add(gradient_id)
+
+            if gradient_id in gradient_colors:
+                continue
+
+            representative_color: Optional[str] = None
+
+            for stop in gradient.findall(stop_xpath):
+                style = stop.attrib.get("style")
+                color: Optional[str] = None
+
+                if style:
+                    for name, value in _parse_style_declarations(style):
+                        if name == "stop-color" and value:
+                            color = value
+                            break
+
+                if color is None:
+                    color = stop.attrib.get("stop-color")
+
+                if color:
+                    representative_color = color
+                    break
+
+            if representative_color:
+                gradient_colors[gradient_id] = representative_color
+
+    return gradient_colors, gradient_ids
+
+
+def _replace_gradient_references(
+    element: ET.Element,
+    gradient_colors: Dict[str, str],
+    gradient_ids: Set[str],
+) -> bool:
+    """Replace gradient ``url(#id)`` colour references on ``element`` when possible."""
+
+    updated = False
+
+    for attribute in ("fill", "stroke"):
+        raw_value = element.attrib.get(attribute)
+        if not raw_value:
+            continue
+
+        match = _GRADIENT_URL_RE.match(raw_value.strip())
+        if not match:
+            continue
+
+        gradient_id = match.group("id")
+        if gradient_id not in gradient_ids:
+            continue
+
+        fallback = gradient_colors.get(gradient_id, _DEFAULT_GRADIENT_FALLBACK_COLOR)
+
+        element.set(attribute, fallback)
+        updated = True
+
+    style_value = element.attrib.get("style")
+    if style_value:
+        declarations = _parse_style_declarations(style_value)
+        new_declarations: List[Tuple[str, str]] = []
+        style_updated = False
+
+        for name, value in declarations:
+            match = _GRADIENT_URL_RE.match(value)
+            if match and name in {"fill", "stroke"}:
+                gradient_id = match.group("id")
+                if gradient_id in gradient_ids:
+                    fallback = gradient_colors.get(
+                        gradient_id, _DEFAULT_GRADIENT_FALLBACK_COLOR
+                    )
+                    value = fallback
+                    style_updated = True
+            new_declarations.append((name, value))
+
+        if style_updated:
+            element.set("style", _serialize_style_declarations(new_declarations))
+            updated = True
+
+    return updated
+
+
+def _sanitize_svg_for_svglib(svg_markup: str) -> str:
+    """Replace unsupported gradient colour references with solid colours."""
+
+    try:
+        root = ET.fromstring(svg_markup)
+    except ET.ParseError:
+        return svg_markup
+
+    gradient_colors, gradient_ids = _collect_gradient_fallback_colors(root)
+    if not gradient_ids:
+        return svg_markup
+
+    updated = False
+    for element in root.iter():
+        if _replace_gradient_references(element, gradient_colors, gradient_ids):
+            updated = True
+
+    if not updated:
+        return svg_markup
+
+    return ET.tostring(root, encoding="unicode")
+
 
 # MongoDB connection
 mongo_url = os.environ["MONGO_URL"]
@@ -950,7 +1101,8 @@ def _render_svg_on_canvas(
 
     if backend.mode == "svglib" and backend.svg2rlg and backend.render_pdf:
         try:
-            drawing = backend.svg2rlg(BytesIO(svg_markup.encode("utf-8")))
+            sanitized_markup = _sanitize_svg_for_svglib(svg_markup)
+            drawing = backend.svg2rlg(BytesIO(sanitized_markup.encode("utf-8")))
         except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning("Failed to parse SVG using svglib: %s", exc)
             return False

--- a/tests/test_rhyme_svg_loader.py
+++ b/tests/test_rhyme_svg_loader.py
@@ -4,6 +4,7 @@ import sys
 import types
 from io import BytesIO
 from types import SimpleNamespace
+from xml.etree import ElementTree as ET
 
 import pytest
 
@@ -291,3 +292,59 @@ def test_binder_falls_back_to_generated_svg(tmp_path, monkeypatch, stub_pdf_reso
     assert captured["markups"] == [sentinel_svg]
     assert len(draw_calls) == 1
     assert draw_calls[0]["entry"]["rhyme_code"] == rhyme_code
+
+
+def test_sanitize_svg_for_svglib_rewrites_gradient_fill():
+    gradient_svg = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        <defs>
+            <linearGradient id="grad1">
+                <stop offset="0%" style="stop-color:#123456;stop-opacity:1" />
+                <stop offset="100%" style="stop-color:#abcdef;stop-opacity:1" />
+            </linearGradient>
+        </defs>
+        <rect id="rect" width="10" height="10" fill="url(#grad1)" />
+        <circle id="circle" cx="5" cy="5" r="2" style="stroke:url(#grad1);fill:none" />
+    </svg>
+    """
+
+    sanitized = server._sanitize_svg_for_svglib(gradient_svg)
+    assert "url(#grad1)" not in sanitized
+
+    root = ET.fromstring(sanitized)
+    rect = root.find(".//{http://www.w3.org/2000/svg}rect")
+    circle = root.find(".//{http://www.w3.org/2000/svg}circle")
+
+    assert rect is not None and rect.attrib.get("fill") == "#123456"
+    assert circle is not None
+    assert "url(#grad1)" not in circle.attrib.get("style", "")
+    assert "#123456" in circle.attrib.get("style", "")
+
+
+def test_sanitize_svg_for_svglib_defaults_when_gradient_has_no_stop_color():
+    gradient_svg = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        <defs>
+            <linearGradient id="grad2">
+                <stop offset="0%" />
+            </linearGradient>
+        </defs>
+        <rect id="rect" width="10" height="10" fill="url(#grad2)" />
+    </svg>
+    """
+
+    sanitized = server._sanitize_svg_for_svglib(gradient_svg)
+
+    assert "url(#grad2)" not in sanitized
+
+    rect = ET.fromstring(sanitized).find(".//{http://www.w3.org/2000/svg}rect")
+    assert rect is not None
+    assert (
+        rect.attrib.get("fill")
+        == server._DEFAULT_GRADIENT_FALLBACK_COLOR
+    )
+
+
+def test_sanitize_svg_for_svglib_returns_original_on_parse_error():
+    malformed_svg = "<svg><"
+    assert server._sanitize_svg_for_svglib(malformed_svg) == malformed_svg


### PR DESCRIPTION
## Summary
- track defined gradient ids and replace unsupported url(#...) references with either their sampled stop colour or a default fallback in both server implementations
- update the SVG sanitiser to always strip gradient urls and default to black when no stop colour is available
- add regression coverage verifying gradients without explicit stop colours still lose their url(#...) references

## Testing
- pytest tests/test_rhyme_svg_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68dcd9073e6c8325bd9d627c3b7be6b3