### PR TITLE
Fix SVG scaling to prevent overflow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -277,7 +277,7 @@ body {
 .rhyme-slot-container.has-svg .rhyme-svg-content {
   padding: 0;
   display: flex;
-  align-items: stretch;
+  align-items: center;
   justify-content: center;
 }
 
@@ -331,17 +331,20 @@ body {
 }
 
 .rhyme-svg-content svg {
-  width: 100% !important;
+  display: block;
+  width: auto !important;
   height: auto !important;
+  max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  display: block;
 }
 
 .rhyme-slot-container.has-svg .rhyme-svg-content svg {
-  height: 100% !important;
-  width: 100% !important;
-  flex: 1 1 auto;
+  width: auto !important;
+  height: auto !important;
+  max-width: 100%;
+  max-height: 100%;
+  flex: 0 1 auto;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -69,6 +69,22 @@ const sanitizeRhymeSvgContent = (svgContent, rhymeCode) => {
     svgElement.removeAttribute('width');
     svgElement.removeAttribute('height');
 
+    const inlineStyleAttr = svgElement.getAttribute('style');
+    if (typeof inlineStyleAttr === 'string' && inlineStyleAttr.trim().length > 0) {
+      const filteredStyleRules = inlineStyleAttr
+        .split(';')
+        .map((rule) => rule.trim())
+        .filter((rule) =>
+          rule.length > 0 && !/^width\s*:/i.test(rule) && !/^height\s*:/i.test(rule)
+        );
+
+      if (filteredStyleRules.length > 0) {
+        svgElement.setAttribute('style', `${filteredStyleRules.join('; ')};`);
+      } else {
+        svgElement.removeAttribute('style');
+      }
+    }
+
     if (!svgElement.getAttribute('viewBox')) {
       if (Number.isFinite(widthValue) && Number.isFinite(heightValue) && widthValue > 0 && heightValue > 0) {
         svgElement.setAttribute('viewBox', `0 0 ${widthValue} ${heightValue}`);


### PR DESCRIPTION
## Summary
- filter out inline width and height declarations when sanitizing rhyme SVGs
- adjust rhyme SVG container styles so the artwork scales proportionally within its slot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dce9d3c69c8325bb487b4e02ac32e8