### PR TITLE
Fix SVG scaling to fit rhyme slots

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -332,19 +332,20 @@ body {
 
 .rhyme-svg-content svg {
   display: block;
-  width: auto !important;
-  height: auto !important;
+  width: 100% !important;
+  height: 100% !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
 }
 
 .rhyme-slot-container.has-svg .rhyme-svg-content svg {
-  width: auto !important;
-  height: auto !important;
+  width: 100% !important;
+  height: 100% !important;
   max-width: 100%;
   max-height: 100%;
   flex: 0 1 auto;
+  object-fit: contain;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- ensure SVGs inside rhyme slots scale to the container bounds
- use full width and height with object-fit to prevent overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dceb98183c83258c5812a4dafb7905