### PR TITLE
Adjust cover image aspect handling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -91,9 +91,7 @@ const sanitizeRhymeSvgContent = (svgContent, rhymeCode) => {
       }
     }
 
-    if (!svgElement.getAttribute('preserveAspectRatio')) {
-      svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-    }
+    svgElement.setAttribute('preserveAspectRatio', 'xMidYMid slice');
 
     const viewBoxAttr = svgElement.getAttribute('viewBox');
     let viewBoxWidth;

--- a/frontend/src/components/CoverPageWorkflow.jsx
+++ b/frontend/src/components/CoverPageWorkflow.jsx
@@ -271,12 +271,17 @@ const updateNodeImage = (nodes, value) => {
       }
 
       if (node.tagName?.toLowerCase() === 'image') {
-        node.setAttribute('preserveAspectRatio', node.getAttribute('preserveAspectRatio') || 'xMidYMid meet');
+        node.setAttribute('preserveAspectRatio', 'xMidYMid slice');
       }
 
       const imgChild = node.tagName?.toLowerCase() === 'image' ? null : node.querySelector('img');
       if (imgChild) {
         imgChild.setAttribute('src', imageValue);
+        if (imgChild.style) {
+          imgChild.style.objectFit = imgChild.style.objectFit || 'cover';
+          imgChild.style.width = imgChild.style.width || '100%';
+          imgChild.style.height = imgChild.style.height || '100%';
+        }
       }
     } else {
       node.removeAttribute('href');


### PR DESCRIPTION
## Summary
- ensure rendered SVGs default to slice aspect ratio so avatar imagery fills its frame
- normalize personalised cover image fallbacks to use cover-fit sizing when an <img> element is present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dceea468a48325a063fcf3e3430844