### PR TITLE
Adjust rhyme SVG scaling to fit slot layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -333,7 +333,7 @@ body {
 .rhyme-svg-content svg {
   display: block;
   width: 100% !important;
-  height: 100% !important;
+  height: auto !important;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
@@ -341,7 +341,7 @@ body {
 
 .rhyme-slot-container.has-svg .rhyme-svg-content svg {
   width: 100% !important;
-  height: 100% !important;
+  height: auto !important;
   max-width: 100%;
   max-height: 100%;
   flex: 0 1 auto;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -91,7 +91,7 @@ const sanitizeRhymeSvgContent = (svgContent, rhymeCode) => {
       }
     }
 
-    svgElement.setAttribute('preserveAspectRatio', 'xMidYMid slice');
+    svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
 
     const viewBoxAttr = svgElement.getAttribute('viewBox');
     let viewBoxWidth;


### PR DESCRIPTION
## Summary
- update the SVG sanitiser to use `preserveAspectRatio="xMidYMid meet"` so assets scale inside their slots
- change the rhyme slot CSS so embedded SVGs keep their aspect ratio while expanding to the container width

## Testing
- yarn test --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68dcf2bcef908325a4992c6ffbf8250d