### PR TITLE
Default cover assets to network share

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -45,6 +45,9 @@ load_dotenv(ROOT_DIR / ".env")
 
 logger = logging.getLogger(__name__)
 RHYME_SVG_BASE_PATH = Path(r"\\pixartnas\home\RHYMES & STORIES\NEW\Rhymes\SVGs")
+DEFAULT_COVER_SVG_BASE_PATH = Path(
+    r"\\pixartnas\home\Project ABC\Project ABC Cover\background\Sample"
+)
 
 
 @dataclass(frozen=True)
@@ -93,7 +96,9 @@ def _resolve_cover_svg_base_path() -> Optional[Path]:
 
     base_path = os.environ.get("COVER_SVG_BASE_PATH")
     if not base_path:
-        return None
+        # Default to the shared network location for cover assets when no override
+        # is provided via environment variables.
+        return DEFAULT_COVER_SVG_BASE_PATH
 
     try:
         return Path(base_path).expanduser()


### PR DESCRIPTION
## Summary
- add a default cover SVG base path pointing to the shared network location
- fall back to the shared path when COVER_SVG_BASE_PATH is not provided via environment variables

## Testing
- pytest *(fails: missing optional dependencies `requests` and `PIL` in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df513be61c83258115d526fc16d096