### PR TITLE
Normalize configured CORS origins

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 from dataclasses import dataclass
 from pydantic import BaseModel, Field
-from typing import Callable, List, Dict, Optional, Any, Tuple, Literal
+from typing import Callable, List, Dict, Optional, Any, Tuple, Literal, Iterable, Set
 from io import BytesIO
 from functools import lru_cache
 from shutil import copy2
@@ -619,17 +619,42 @@ def _load_rhyme_svg_markup(rhyme_code: str) -> _SvgDocument:
     return _SvgDocument(generate_rhyme_svg(rhyme_code), None)
 
 
+def _normalize_cors_origin(origin: str) -> Optional[str]:
+    """Return a sanitized representation of a configured CORS origin."""
+
+    trimmed = origin.strip()
+    if not trimmed:
+        return None
+
+    if trimmed == "*":
+        return trimmed
+
+    return trimmed.rstrip("/")
+
+
 def _parse_csv(value: Optional[str], *, default: Optional[List[str]] = None) -> List[str]:
     """Return a normalized list from a comma separated string."""
 
-    if value is None:
-        return list(default or [])
+    def _collect(entries: Iterable[str]) -> List[str]:
+        normalized: List[str] = []
+        seen: Set[str] = set()
 
-    entries = [item.strip() for item in value.split(",") if item.strip()]
-    if entries:
-        return entries
+        for raw_entry in entries:
+            normalized_entry = _normalize_cors_origin(raw_entry)
+            if not normalized_entry or normalized_entry in seen:
+                continue
 
-    return list(default or [])
+            normalized.append(normalized_entry)
+            seen.add(normalized_entry)
+
+        return normalized
+
+    if value is not None:
+        parsed = _collect(value.split(","))
+        if parsed:
+            return parsed
+
+    return _collect(default or [])
 
 
 app = FastAPI()

--- a/tests/test_cors_configuration.py
+++ b/tests/test_cors_configuration.py
@@ -1,0 +1,71 @@
+import ast
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+
+import pytest
+
+MODULE_PATHS = {
+    "backend.s1": Path("backend/s1.py"),
+    "backend.server": Path("backend/server.py"),
+}
+
+
+def _load_parse_csv(path: Path):
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    segments = {}
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in {
+            "_normalize_cors_origin",
+            "_parse_csv",
+        }:
+            segments[node.name] = ast.get_source_segment(source, node)
+
+    namespace = {}
+    globals_dict = {
+        "__builtins__": __builtins__,
+        "Optional": Optional,
+        "List": List,
+        "Iterable": Iterable,
+        "Set": Set,
+    }
+
+    exec(segments["_normalize_cors_origin"], globals_dict, namespace)
+    globals_dict = {**globals_dict, **namespace}
+    exec(segments["_parse_csv"], globals_dict, namespace)
+
+    return namespace["_parse_csv"]
+
+
+@pytest.mark.parametrize("module_name", MODULE_PATHS.keys())
+def test_parse_csv_strips_trailing_slash(module_name):
+    parse_csv = _load_parse_csv(MODULE_PATHS[module_name])
+
+    assert parse_csv(" http://localhost:3000/ ", default=None) == ["http://localhost:3000"]
+
+
+@pytest.mark.parametrize("module_name", MODULE_PATHS.keys())
+def test_parse_csv_deduplicates_and_trims(module_name):
+    parse_csv = _load_parse_csv(MODULE_PATHS[module_name])
+
+    result = parse_csv("http://api.test, http://api.test/ , https://app.test/", default=None)
+
+    assert result == ["http://api.test", "https://app.test"]
+
+
+@pytest.mark.parametrize("module_name", MODULE_PATHS.keys())
+def test_parse_csv_falls_back_to_default_when_empty(module_name):
+    parse_csv = _load_parse_csv(MODULE_PATHS[module_name])
+
+    assert parse_csv(" ,  , ", default=["https://fallback.test/"]) == [
+        "https://fallback.test"
+    ]
+
+
+@pytest.mark.parametrize("module_name", MODULE_PATHS.keys())
+def test_parse_csv_preserves_wildcard_origin(module_name):
+    parse_csv = _load_parse_csv(MODULE_PATHS[module_name])
+
+    assert parse_csv(None, default=["*"]) == ["*"]
+    assert parse_csv("*", default=None) == ["*"]


### PR DESCRIPTION
## Summary
- normalize configured CORS origins so trailing slashes are removed and duplicates dropped before configuring middleware
- mirror the normalization helper across both FastAPI entry modules
- add focused tests to ensure the origin parser trims, deduplicates, and respects fallbacks

## Testing
- pytest tests/test_cors_configuration.py

------
https://chatgpt.com/codex/tasks/task_b_68df50c902ac83259358aae6df770e9c