### PR TITLE
Use relative API base URL by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ The FastAPI service is defined in [`backend/server.py`](backend/server.py) and e
 Before starting the FastAPI service, make sure a MongoDB server is available. You can run it locally at `mongodb://localhost:27017` or supply a hosted MongoDB URL via `MONGO_URL`.
 
 ## Frontend Setup
-The React client reads its backend URL from `frontend/src/App.js`. Configure and start it by following these steps:
+The React client automatically targets the same origin as the page serving it. When you need to talk to a backend hosted at a
+different URL, provide an override through `frontend/.env`:
 
-1. Create `frontend/.env` with the lines:
+1. (Optional) Create `frontend/.env` with the following entry to point the UI at a different backend host:
    ```env
    REACT_APP_BACKEND_URL=http://localhost:8000
    ```

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import { Separator } from './components/ui/separator';
 import { toast } from 'sonner';
 import { Toaster } from './components/ui/sonner';
 import CoverPageWorkflow from './components/CoverPageWorkflow';
+import { API_BASE_URL } from './lib/utils';
 
 
 // Icons
@@ -33,8 +34,7 @@ import {
   Clock
 } from 'lucide-react';
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
-const API = `${BACKEND_URL}/api`;
+const API = API_BASE_URL || '/api';
 
 const GRADE_OPTIONS = [
   { id: 'nursery', name: 'Nursery', color: 'from-pink-400 to-rose-400', icon: '🌸' },


### PR DESCRIPTION
## Summary
- update the React app to reuse the shared API base URL helper so it defaults to the hosting origin
- document that the frontend now targets the same origin by default and the backend URL override is optional

## Testing
- yarn test --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68df58ce30d4832585db5a055f0d4a37