### PR TITLE
Adjust personalised image alignment

### DIFF
--- a/frontend/src/components/CoverPageWorkflow.jsx
+++ b/frontend/src/components/CoverPageWorkflow.jsx
@@ -348,7 +348,7 @@ const updateNodeImage = (nodes, value) => {
       }
 
       if (node.tagName?.toLowerCase() === 'image') {
-        node.setAttribute('preserveAspectRatio', 'xMidYMid slice');
+        node.setAttribute('preserveAspectRatio', 'xMidYMin slice');
       }
 
       const imgChild = node.tagName?.toLowerCase() === 'image' ? null : node.querySelector('img');
@@ -356,8 +356,10 @@ const updateNodeImage = (nodes, value) => {
         imgChild.setAttribute('src', imageValue);
         if (imgChild.style) {
           imgChild.style.objectFit = imgChild.style.objectFit || 'cover';
+          imgChild.style.objectPosition = imgChild.style.objectPosition || '50% 0%';
           imgChild.style.width = imgChild.style.width || '100%';
           imgChild.style.height = imgChild.style.height || '100%';
+          imgChild.style.backgroundColor = imgChild.style.backgroundColor || 'transparent';
         }
       }
     } else {
@@ -374,6 +376,10 @@ const updateNodeImage = (nodes, value) => {
       const imgChild = node.tagName?.toLowerCase() === 'image' ? null : node.querySelector('img');
       if (imgChild) {
         imgChild.removeAttribute('src');
+        if (imgChild.style) {
+          imgChild.style.removeProperty('object-position');
+          imgChild.style.removeProperty('background-color');
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- align personalised SVG images to the top of their containers so faces sit correctly within the artwork
- update injected `<img>` fallbacks to use transparent backgrounds and reset styles when cleared

## Testing
- yarn test --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68df7a17394c8325b3f459599f1ee22e