### PR TITLE
Inline bitmap assets when rendering binder PDFs

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1484,6 +1484,17 @@ def _render_svg_on_canvas(
     source_path = svg_document.source_path
     sanitized_markup = _sanitize_svg_for_svglib(svg_markup)
 
+    if source_path is not None:
+        localized_markup = _localize_svg_image_assets(
+            sanitized_markup,
+            source_path,
+            rhyme_code or "unknown",
+            inline_mode=True,
+            preprocess_for_pdf=True,
+        )
+        if localized_markup != sanitized_markup:
+            sanitized_markup = localized_markup
+
     temp_svg_path: Optional[Path] = None
 
     if vector_backend_available:


### PR DESCRIPTION
## Summary
- inline external bitmap references before svglib renders binder SVGs so PDF exports show images like the browser
- extend the unit test harness with PIL stubs and assertions covering the new data URI behaviour

## Testing
- pytest tests/test_rhyme_svg_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68df96bc558c8325855f3cde8a45eceb