### PR TITLE
Align rhyme carousel containers and spacing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -133,10 +133,9 @@ body {
 }
 
 .a4-preview {
-
   width: clamp(260px, 58vw, 720px);
-  height: min(calc(100vh - 140px), 980px);
-
+  height: auto;
+  max-height: min(calc(100vh - 140px), 980px);
   background: #fff;
   border-radius: 28px;
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -150,8 +149,8 @@ body {
   .a4-preview {
 
     width: clamp(240px, 75vw, 560px);
-    height: min(calc(100vh - 120px), 900px);
-
+    height: auto;
+    max-height: min(calc(100vh - 120px), 900px);
     border-radius: 24px;
   }
 }
@@ -166,38 +165,52 @@ body {
 
 .rhyme-page-grid {
   display: flex;
-  flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
-  gap: clamp(12px, 2.4vw, 24px);
+  gap: 0;
 }
 
 .rhyme-slot {
+  --slot-padding: clamp(18px, 3.6vw, 32px);
   width: 100%;
-  flex: 1 1 50%;
+  flex: 0 0 auto;
   min-height: 0;
-  padding: clamp(18px, 3.6vw, 32px);
+  padding: var(--slot-padding) var(--slot-padding) 0;
   display: flex;
   flex-direction: column;
-  gap: clamp(14px, 2.8vw, 22px);
+  gap: 0;
+}
+
+.rhyme-slot + .rhyme-slot {
+  padding-top: 0;
+}
+
+.rhyme-slot:last-of-type {
+  padding-bottom: var(--slot-padding);
 }
 
 .double-page-slot {
   flex: 1 1 auto;
+  padding: clamp(18px, 3.6vw, 32px);
+}
+
+.double-page-slot:last-of-type {
+  padding-bottom: clamp(18px, 3.6vw, 32px);
 }
 
 .rhyme-slot > .relative {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-height: 0;
   width: 100%;
-  height: 100%;
+  height: auto;
   display: flex;
   flex-direction: column;
 }
 
 .rhyme-slot-wrapper {
-  min-height: clamp(360px, 58vh, 760px);
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+  min-height: 0;
+  height: auto;
 }
 
 .rhyme-slot-container {
@@ -219,7 +232,7 @@ body {
 
 .rhyme-slot-container.has-svg {
   border-radius: 0;
-  min-height: clamp(360px, 58vh, 760px);
+  min-height: 0;
 }
 
 .rhyme-page-grid > .rhyme-slot:first-of-type .rhyme-slot-container.has-svg {
@@ -239,7 +252,7 @@ body {
 .rhyme-slot-container.has-svg {
   padding: 0;
   align-items: stretch;
-  height: 100%;
+  height: auto;
   display: flex;
 }
 


### PR DESCRIPTION
## Summary
- let the A4 preview wrapper size to its content so the carousel sits higher on the screen
- remove extra gaps and forced min-heights from rhyme slots so the top and bottom panes stay flush
- keep the SVG containers flexible so artwork scales responsively without distortion

## Testing
- yarn start

------
https://chatgpt.com/codex/tasks/task_b_68dfa32f0ac08325af2d6f37617ac0ce