### PR TITLE
Adjust rhyme selection layout spacing and scaling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -173,7 +173,7 @@ body {
 .rhyme-slot {
   --slot-padding: clamp(18px, 3.6vw, 32px);
   width: 100%;
-  flex: 0 0 auto;
+  flex: 1 1 0%;
   min-height: 0;
   padding: var(--slot-padding) var(--slot-padding) 0;
   display: flex;
@@ -199,7 +199,7 @@ body {
 }
 
 .rhyme-slot > .relative {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   min-height: 0;
   width: 100%;
   height: auto;
@@ -208,7 +208,7 @@ body {
 }
 
 .rhyme-slot-wrapper {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   min-height: 0;
   height: auto;
 }
@@ -252,8 +252,9 @@ body {
 .rhyme-slot-container.has-svg {
   padding: 0;
   align-items: stretch;
-  height: auto;
+  height: 100%;
   display: flex;
+  flex: 1 1 auto;
 }
 
 .rhyme-slot-container.double-page {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1674,7 +1674,7 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
               <div className="flex h-full w-full flex-col">
 
                 {/* Navigation Controls */}
-                <div className="flex-shrink-0 space-y-6">
+                <div className="flex-shrink-0 space-y-4">
                   <div className="flex items-center justify-between">
                     <Button
                       onClick={() => void handlePageChange(Math.max(0, currentPageIndex - 1))}
@@ -1703,8 +1703,8 @@ const RhymeSelectionPage = ({ school, grade, onBack, onLogout }) => {
                 </div>
 
                 <div className="flex-1 min-h-0 flex flex-col">
-                  <div className="flex-1 min-h-0 py-4">
-                    <div className="flex h-full items-center justify-center">
+                  <div className="flex-1 min-h-0 py-2">
+                    <div className="flex h-full items-start justify-center">
 
                       <div className="relative flex w-full justify-center transition-all duration-300 ease-out">
 


### PR DESCRIPTION
## Summary
- bring the rhyme preview carousel closer to the navigation controls for easier paging
- make rhyme slot containers flex to share height so top and bottom SVGs scale proportionally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dfa98af01c8325a2cc46be0160c88c