### PR TITLE
Refactor backend configuration into modular helpers

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,16 @@
+"""Application helpers for the Rhymes backend service.
+
+This package provides modular building blocks that the legacy ``server``
+module re-exports so that existing imports continue to function.  The
+structure keeps the deployment entry-point stable while allowing the codebase
+to grow in a maintainable fashion.
+"""
+
+from . import config, rhymes, svg_processing
+
+__all__ = [
+    "config",
+    "rhymes",
+    "svg_processing",
+]
+

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,162 @@
+"""Configuration helpers shared across the Rhymes backend modules."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+from xml.etree import ElementTree as ET
+
+from dotenv import load_dotenv
+from fastapi import HTTPException
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+# Ensure environment variables defined in ``backend/.env`` are available before
+# importing submodules that rely on them.
+load_dotenv(ROOT_DIR / ".env")
+
+
+logger = logging.getLogger(__name__)
+
+SVG_NS = "http://www.w3.org/2000/svg"
+XLINK_NS = "http://www.w3.org/1999/xlink"
+
+GRADIENT_URL_RE = re.compile(r"^url\(#(?P<id>[^)]+)\)$")
+CSS_GRADIENT_DECLARATION_RE = re.compile(
+    r"(?P<prop>\b(?:fill|stroke)\s*:\s*)url\(#(?P<id>[^)]+)\)", re.IGNORECASE
+)
+
+
+ET.register_namespace("", SVG_NS)
+ET.register_namespace("xlink", XLINK_NS)
+
+
+IMAGE_CACHE_DIR = ROOT_DIR / "images"
+
+# Default asset directories used when no explicit environment overrides are
+# supplied.  The network locations are preserved so deployments that have the
+# directories mounted continue to function without additional configuration.
+RHYME_SVG_BASE_PATH = Path(r"\\pixartnas\home\RHYMES & STORIES\NEW\Rhymes\SVGs")
+DEFAULT_COVER_SVG_BASE_PATH = Path(
+    r"\\pixartnas\home\Project ABC\Project ABC Cover\background\Sample"
+)
+NETWORK_COVER_SVG_BASE_PATH = Path(
+    r"pixartnas\home\Project ABC\Project ABC Cover\background\Sample\1 Theme\Theme 1 Test\SVGs"
+)
+PACKAGED_COVER_SVG_BASE_PATH = ROOT_DIR / "sample_cover_assets"
+
+
+def resolve_cover_svg_base_path(explicit_path: Optional[str] = None) -> Optional[Path]:
+    """Return the directory that stores cover SVG assets, if available."""
+
+    candidate_paths: List[Optional[Path]] = []
+
+    base_path = explicit_path or os.environ.get("COVER_SVG_BASE_PATH")
+    if base_path:
+        try:
+            candidate_paths.append(Path(base_path).expanduser())
+        except (OSError, RuntimeError) as exc:
+            logger.warning("Invalid COVER_SVG_BASE_PATH '%s': %s", base_path, exc)
+
+    candidate_paths.extend(
+        [
+            NETWORK_COVER_SVG_BASE_PATH,
+            DEFAULT_COVER_SVG_BASE_PATH,
+            PACKAGED_COVER_SVG_BASE_PATH,
+        ]
+    )
+
+    for candidate in candidate_paths:
+        if not candidate:
+            continue
+
+        try:
+            if candidate.exists() and candidate.is_dir():
+                return candidate
+        except OSError as exc:
+            logger.warning("Unable to access cover SVG directory %s: %s", candidate, exc)
+
+    return None
+
+
+def ensure_cover_assets_base_path(base_path: Optional[Path]) -> Path:
+    """Return ``base_path`` or raise an HTTP error when it is unusable."""
+
+    if base_path is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "COVER_SVG_BASE_PATH is not configured on the server. "
+                "Please set it to the directory containing the cover SVG files."
+            ),
+        )
+
+    if not base_path.exists() or not base_path.is_dir():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "The configured COVER_SVG_BASE_PATH does not exist or is not a directory."
+            ),
+        )
+
+    return base_path
+
+
+def _normalize_cors_origin(origin: str) -> Optional[str]:
+    """Return a sanitized representation of a configured CORS origin."""
+
+    trimmed = origin.strip()
+    if not trimmed:
+        return None
+
+    if trimmed == "*":
+        return trimmed
+
+    return trimmed.rstrip("/")
+
+
+def _collect_csv_entries(entries: Iterable[str]) -> List[str]:
+    normalized: List[str] = []
+    seen: Set[str] = set()
+
+    for raw_entry in entries:
+        normalized_entry = _normalize_cors_origin(raw_entry)
+        if not normalized_entry or normalized_entry in seen:
+            continue
+
+        normalized.append(normalized_entry)
+        seen.add(normalized_entry)
+
+    return normalized
+
+
+def _parse_csv(value: Optional[str], *, default: Optional[List[str]] = None) -> List[str]:
+    """Return a normalized list from a comma separated string."""
+
+    if value is not None:
+        parsed = _collect_csv_entries(value.split(","))
+        if parsed:
+            return parsed
+
+    return _collect_csv_entries(default or [])
+
+
+__all__ = [
+    "CSS_GRADIENT_DECLARATION_RE",
+    "GRADIENT_URL_RE",
+    "IMAGE_CACHE_DIR",
+    "NETWORK_COVER_SVG_BASE_PATH",
+    "PACKAGED_COVER_SVG_BASE_PATH",
+    "RHYME_SVG_BASE_PATH",
+    "SVG_NS",
+    "XLINK_NS",
+    "ensure_cover_assets_base_path",
+    "resolve_cover_svg_base_path",
+    "_normalize_cors_origin",
+    "_parse_csv",
+]
+

--- a/backend/app/rhymes.py
+++ b/backend/app/rhymes.py
@@ -1,0 +1,62 @@
+"""Rhymes catalogue utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .config import ROOT_DIR
+
+logger = logging.getLogger(__name__)
+
+
+def _load_rhymes(path: Path) -> Dict[str, List[str | float]]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:  # pragma: no cover - configuration error
+        logger.error("Rhymes catalogue %s could not be found.", path)
+        raise
+
+
+RHYMES_DATA: Dict[str, List[str | float]] = _load_rhymes(ROOT_DIR / "rhymes.json")
+
+
+def generate_rhyme_svg(
+    rhyme_code: str,
+    rhymes_data: Optional[Dict[str, List[str | float]]] = None,
+) -> str:
+    """Create SVG markup for a rhyme card."""
+
+    catalogue = rhymes_data or RHYMES_DATA
+
+    if rhyme_code not in catalogue:
+        raise KeyError("Rhyme not found")
+
+    rhyme_name, pages = catalogue[rhyme_code]
+
+    return f"""
+    <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" style="stop-color:#ff6b6b;stop-opacity:1" />
+                <stop offset="100%" style="stop-color:#4ecdc4;stop-opacity:1" />
+            </linearGradient>
+        </defs>
+        <rect width="400" height="300" fill="url(#grad1)" rx="15"/>
+        <text x="200" y="100" font-family="Arial, sans-serif" font-size="16" font-weight="bold"
+              text-anchor="middle" fill="white">{rhyme_name}</text>
+        <text x="200" y="130" font-family="Arial, sans-serif" font-size="12"
+              text-anchor="middle" fill="white">Code: {rhyme_code}</text>
+        <text x="200" y="160" font-family="Arial, sans-serif" font-size="12"
+              text-anchor="middle" fill="white">Pages: {pages}</text>
+        <circle cx="200" cy="220" r="30" fill="rgba(255,255,255,0.3)" stroke="white" stroke-width="2"/>
+        <text x="200" y="225" font-family="Arial, sans-serif" font-size="20"
+              text-anchor="middle" fill="white">♪</text>
+    </svg>
+    """
+
+
+__all__ = ["RHYMES_DATA", "generate_rhyme_svg"]
+

--- a/backend/app/svg_processing.py
+++ b/backend/app/svg_processing.py
@@ -1,0 +1,512 @@
+"""SVG asset handling helpers."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import tempfile
+from dataclasses import dataclass
+from functools import lru_cache
+from io import BytesIO
+from pathlib import Path
+from shutil import copy2
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import quote, unquote, urlparse
+from xml.etree import ElementTree as ET
+
+from PIL import Image
+
+from . import config
+from .rhymes import RHYMES_DATA, generate_rhyme_svg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SvgDocument:
+    """Container describing SVG markup and, optionally, its source path."""
+
+    markup: str
+    source_path: Optional[Path]
+
+
+def resolve_rhyme_svg_path(base_path: Optional[Path], rhyme_code: str) -> Optional[Path]:
+    """Return the network SVG path for ``rhyme_code`` if it exists."""
+
+    if base_path is None:
+        return None
+
+    candidate = base_path / f"{rhyme_code}.svg"
+
+    try:
+        if candidate.is_file():
+            return candidate
+
+        if candidate.exists():
+            logger.warning(
+                "Authored SVG for rhyme %s exists at %s but is not a file.",
+                rhyme_code,
+                candidate,
+            )
+        else:
+            logger.warning(
+                "SVG file not found for rhyme %s in %s (expected %s)",
+                rhyme_code,
+                base_path,
+                candidate,
+            )
+    except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
+        logger.error(
+            "Unable to access SVG for rhyme %s at %s: %s",
+            rhyme_code,
+            candidate,
+            exc,
+        )
+
+    return None
+
+
+def build_cover_asset_manifest(
+    base_path: Path, *, include_markup: bool = False
+) -> List[Dict[str, Any]]:
+    """Build a manifest describing all SVG cover assets under ``base_path``."""
+
+    assets: List[Dict[str, Any]] = []
+
+    for svg_path in sorted(base_path.rglob("*.svg")):
+        if not svg_path.is_file():
+            continue
+
+        try:
+            relative_path = svg_path.relative_to(base_path)
+        except ValueError:
+            # Skip files that fall outside the configured base directory.
+            continue
+
+        relative_posix = relative_path.as_posix()
+        manifest_entry: Dict[str, Any] = {
+            "fileName": svg_path.name,
+            "path": relative_posix,
+            "url": f"/api/cover-assets/svg/{quote(relative_posix, safe='/')}",
+        }
+
+        if include_markup:
+            try:
+                svg_text = svg_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                svg_text = svg_path.read_bytes().decode("utf-8", errors="replace")
+            except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
+                logger.error("Unable to read cover SVG '%s': %s", svg_path, exc)
+                svg_text = ""
+
+            manifest_entry["svg"] = svg_text
+
+        assets.append(manifest_entry)
+
+    return assets
+
+
+def _parse_style_declarations(style: str) -> List[Tuple[str, str]]:
+    """Return the CSS declarations contained in ``style`` preserving order."""
+
+    declarations: List[Tuple[str, str]] = []
+    for raw_entry in style.split(";"):
+        if not raw_entry.strip():
+            continue
+
+        if ":" not in raw_entry:
+            continue
+
+        property_name, value = raw_entry.split(":", 1)
+        declarations.append((property_name.strip(), value.strip()))
+
+    return declarations
+
+
+def _serialize_style_declarations(declarations: List[Tuple[str, str]]) -> str:
+    """Serialize ``declarations`` back into an inline CSS string."""
+
+    return ";".join(f"{name}:{value}" for name, value in declarations)
+
+
+def _collect_gradient_fallback_colors(root: ET.Element) -> Dict[str, str]:
+    """Return a mapping of gradient ids to representative stop colours."""
+
+    gradient_colors: Dict[str, str] = {}
+    stop_xpath = f".//{{{config.SVG_NS}}}stop"
+
+    for gradient_tag in (
+        f".//{{{config.SVG_NS}}}linearGradient",
+        f".//{{{config.SVG_NS}}}radialGradient",
+    ):
+        for gradient in root.findall(gradient_tag):
+            gradient_id = gradient.attrib.get("id")
+            if not gradient_id or gradient_id in gradient_colors:
+                continue
+
+            representative_color: Optional[str] = None
+
+            for stop in gradient.findall(stop_xpath):
+                style = stop.attrib.get("style")
+                color: Optional[str] = None
+
+                if style:
+                    for name, value in _parse_style_declarations(style):
+                        if name == "stop-color" and value:
+                            color = value
+                            break
+
+                if color is None:
+                    color = stop.attrib.get("stop-color")
+
+                if color:
+                    representative_color = color
+                    break
+
+            if representative_color:
+                gradient_colors[gradient_id] = representative_color
+
+    return gradient_colors
+
+
+def _replace_gradient_references(
+    element: ET.Element, gradient_colors: Dict[str, str]
+) -> bool:
+    """Replace gradient ``url(#id)`` colour references on ``element`` when possible."""
+
+    updated = False
+
+    for attribute in ("fill", "stroke"):
+        raw_value = element.attrib.get(attribute)
+        if not raw_value:
+            continue
+
+        match = config.GRADIENT_URL_RE.match(raw_value.strip())
+        if not match:
+            continue
+
+        gradient_id = match.group("id")
+        fallback = gradient_colors.get(gradient_id)
+        if not fallback:
+            continue
+
+        element.set(attribute, fallback)
+        updated = True
+
+    style_value = element.attrib.get("style")
+    if style_value:
+        declarations = _parse_style_declarations(style_value)
+        new_declarations: List[Tuple[str, str]] = []
+        style_updated = False
+
+        for name, value in declarations:
+            match = config.GRADIENT_URL_RE.match(value)
+            if match and name in {"fill", "stroke"}:
+                fallback = gradient_colors.get(match.group("id"))
+                if fallback:
+                    value = fallback
+                    style_updated = True
+            new_declarations.append((name, value))
+
+        if style_updated:
+            element.set("style", _serialize_style_declarations(new_declarations))
+            updated = True
+
+    return updated
+
+
+def _replace_gradient_references_in_css(
+    css_text: str, gradient_colors: Dict[str, str]
+) -> Tuple[str, bool]:
+    """Replace ``fill``/``stroke`` gradient references inside inline CSS blocks."""
+
+    updated = False
+
+    def _replace(match):
+        gradient_id = match.group("id")
+        fallback = gradient_colors.get(gradient_id)
+        if not fallback:
+            return match.group(0)
+
+        nonlocal updated
+        updated = True
+        return f"{match.group('prop')}{fallback}"
+
+    return config.CSS_GRADIENT_DECLARATION_RE.sub(_replace, css_text), updated
+
+
+def sanitize_svg_for_svglib(svg_markup: str) -> str:
+    """Replace unsupported gradient colour references with solid colours."""
+
+    try:
+        root = ET.fromstring(svg_markup)
+    except ET.ParseError:
+        return svg_markup
+
+    gradient_colors = _collect_gradient_fallback_colors(root)
+    if not gradient_colors:
+        return svg_markup
+
+    updated = False
+    for element in root.iter():
+        if _replace_gradient_references(element, gradient_colors):
+            updated = True
+            continue
+
+        if element.tag == f"{{{config.SVG_NS}}}style" and element.text:
+            replaced_text, css_updated = _replace_gradient_references_in_css(
+                element.text, gradient_colors
+            )
+            if css_updated:
+                element.text = replaced_text
+                updated = True
+
+    if not updated:
+        return svg_markup
+
+    return ET.tostring(root, encoding="unicode")
+
+
+def svg_requires_raster_backend(svg_document: SvgDocument) -> bool:
+    """Return ``True`` when the SVG should be rasterised for PDF output."""
+
+    try:
+        root = ET.fromstring(svg_document.markup)
+    except ET.ParseError:
+        return False
+
+    image_xpath = f".//{{{config.SVG_NS}}}image"
+
+    for image in root.findall(image_xpath):
+        href_value = (
+            image.get(f"{{{config.XLINK_NS}}}href")
+            or image.get("href")
+            or ""
+        ).strip()
+        if not href_value:
+            continue
+
+        href_lower = href_value.lower()
+        if href_lower.startswith("data:"):
+            continue
+
+        parsed = urlparse(href_value)
+        candidate = (parsed.path or href_value).lower()
+        if candidate.endswith((".png", ".apng")):
+            return True
+
+        type_attr = (image.get("type") or "").lower()
+        if type_attr in {"image/png", "image/apng"}:
+            return True
+
+    return False
+
+
+def ensure_image_cache_dir(cache_dir: Path) -> Path:
+    """Return the local image cache directory, creating it if needed."""
+
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - filesystem permissions errors
+        logger.error("Unable to create image cache directory %s: %s", cache_dir, exc)
+        raise
+
+    return cache_dir
+
+
+def _prepare_inline_image_asset(
+    asset_path: Path,
+    rhyme_code: str,
+    *,
+    preprocess_for_pdf: bool = False,
+) -> Optional[Tuple[bytes, str]]:
+    """Return image bytes and mime type for embedding in SVG."""
+
+    if preprocess_for_pdf:
+        suffix = asset_path.suffix.lower()
+        try:
+            if suffix in {".png", ".apng"}:
+                with Image.open(asset_path) as image:
+                    prepared = image.convert("RGBA")
+                    buffer = BytesIO()
+                    prepared.save(buffer, format="PNG")
+                    return buffer.getvalue(), "image/png"
+            if suffix in {".jpg", ".jpeg"}:
+                with Image.open(asset_path) as image:
+                    rgba_image = image.convert("RGBA")
+                    background = Image.new("RGBA", rgba_image.size, (255, 255, 255, 255))
+                    background.alpha_composite(rgba_image)
+                    buffer = BytesIO()
+                    background.save(buffer, format="PNG")
+                    return buffer.getvalue(), "image/png"
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "Failed to preprocess bitmap asset '%s' for rhyme %s at %s: %s",
+                asset_path.name,
+                rhyme_code,
+                asset_path,
+                exc,
+            )
+
+    try:
+        raw_bytes = asset_path.read_bytes()
+    except OSError as exc:
+        logger.warning(
+            "Unable to read bitmap asset '%s' for rhyme %s at %s: %s",
+            asset_path.name,
+            rhyme_code,
+            asset_path,
+            exc,
+        )
+        return None
+
+    mime_type, _ = mimetypes.guess_type(asset_path.name)
+    if preprocess_for_pdf and mime_type is None:
+        mime_type = "image/png"
+    if not mime_type:
+        mime_type = "application/octet-stream"
+
+    return raw_bytes, mime_type
+
+
+def localize_svg_image_assets(
+    svg_text: str,
+    source_path: Path,
+    rhyme_code: str,
+    *,
+    inline_mode: bool = False,
+    preprocess_for_pdf: bool = False,
+    cache_dir: Optional[Path] = None,
+) -> str:
+    """Return ``svg_text`` with external image references localised."""
+
+    if cache_dir is None:
+        cache_dir = config.IMAGE_CACHE_DIR
+
+    try:
+        root = ET.fromstring(svg_text)
+    except ET.ParseError:
+        return svg_text
+
+    modified = False
+    image_xpath = f".//{{{config.SVG_NS}}}image"
+
+    for image in root.findall(image_xpath):
+        href_value = (
+            image.get(f"{{{config.XLINK_NS}}}href")
+            or image.get("href")
+            or ""
+        ).strip()
+        if not href_value:
+            continue
+
+        parsed = urlparse(href_value)
+        if parsed.scheme in {"http", "https", "data"}:
+            continue
+
+        asset_path = (source_path.parent / Path(unquote(parsed.path))).resolve()
+        try:
+            asset_path.relative_to(source_path.parent)
+        except ValueError:
+            continue
+
+        prepared_asset: Optional[Tuple[bytes, str]]
+        prepared_asset = _prepare_inline_image_asset(
+            asset_path,
+            rhyme_code,
+            preprocess_for_pdf=preprocess_for_pdf,
+        )
+
+        if prepared_asset is None:
+            continue
+
+        asset_bytes, mime_type = prepared_asset
+
+        if inline_mode:
+            data_uri = base64.b64encode(asset_bytes).decode("ascii")
+            image.set("href", f"data:{mime_type};base64,{data_uri}")
+            image.set(f"{{{config.XLINK_NS}}}href", f"data:{mime_type};base64,{data_uri}")
+            modified = True
+            continue
+
+        cache_directory = ensure_image_cache_dir(cache_dir)
+        cache_file = cache_directory / asset_path.name
+        try:
+            copy2(asset_path, cache_file)
+        except OSError as exc:
+            logger.warning(
+                "Unable to copy asset '%s' for rhyme %s to cache %s: %s",
+                asset_path.name,
+                rhyme_code,
+                cache_file,
+                exc,
+            )
+            continue
+
+        new_href = cache_file.name
+        image.set("href", new_href)
+        image.set(f"{{{config.XLINK_NS}}}href", new_href)
+        modified = True
+
+    if not modified:
+        return svg_text
+
+    return ET.tostring(root, encoding="unicode")
+
+
+def _read_packaged_rhyme(rhyme_code: str) -> Optional[SvgDocument]:
+    packaged_path = config.PACKAGED_COVER_SVG_BASE_PATH / f"{rhyme_code}.svg"
+    if not packaged_path.exists():
+        return None
+
+    try:
+        return SvgDocument(packaged_path.read_text(encoding="utf-8"), packaged_path)
+    except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
+        logger.error("Unable to read packaged SVG %s: %s", packaged_path, exc)
+        return None
+
+
+def load_rhyme_svg_markup(
+    rhyme_code: str,
+    base_path: Optional[Path],
+    *,
+    fallback_factory: Optional[Callable[[str], str]] = None,
+) -> SvgDocument:
+    """Return SVG markup and optional source path for ``rhyme_code``."""
+
+    svg_path = resolve_rhyme_svg_path(base_path, rhyme_code)
+
+    if svg_path is not None:
+        try:
+            svg_text = svg_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            logger.warning("SVG file not found for rhyme %s at %s", rhyme_code, svg_path)
+        except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
+            logger.error(
+                "Unable to read SVG for rhyme %s at %s: %s", rhyme_code, svg_path, exc
+            )
+        else:
+            return SvgDocument(svg_text, svg_path)
+
+    packaged = _read_packaged_rhyme(rhyme_code)
+    if packaged is not None:
+        return packaged
+
+    generator = fallback_factory or generate_rhyme_svg
+    return SvgDocument(generator(rhyme_code), None)
+
+
+__all__ = [
+    "RHYMES_DATA",
+    "SvgDocument",
+    "build_cover_asset_manifest",
+    "ensure_image_cache_dir",
+    "generate_rhyme_svg",
+    "localize_svg_image_assets",
+    "load_rhyme_svg_markup",
+    "resolve_rhyme_svg_path",
+    "sanitize_svg_for_svglib",
+    "svg_requires_raster_backend",
+]
+

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,754 +1,70 @@
-from fastapi import FastAPI, APIRouter, HTTPException
-from fastapi.responses import Response
 
-from dotenv import load_dotenv
-from starlette.middleware.cors import CORSMiddleware
+from __future__ import annotations
 
-from motor.motor_asyncio import AsyncIOMotorClient
-import os
 import logging
-import json
-from pathlib import Path
-from dataclasses import dataclass
-from pydantic import BaseModel, Field
-from typing import Callable, List, Dict, Optional, Any, Tuple, Literal, Iterable, Set
-from io import BytesIO
-from functools import lru_cache
-from shutil import copy2
+import os
 import tempfile
-import base64
-import mimetypes
-from urllib.parse import quote, unquote, urlparse
-from xml.etree import ElementTree as ET
-import re
-
 import uuid
 from datetime import datetime
+from dataclasses import dataclass
+from functools import lru_cache
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Set, Tuple
 
-from PIL import Image
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import Response
+from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import BaseModel, Field
+from starlette.middleware.cors import CORSMiddleware
 
-ROOT_DIR = Path(__file__).parent
-
-
-SVG_NS = "http://www.w3.org/2000/svg"
-XLINK_NS = "http://www.w3.org/1999/xlink"
-
-_GRADIENT_URL_RE = re.compile(r"^url\(#(?P<id>[^)]+)\)$")
-_CSS_GRADIENT_DECLARATION_RE = re.compile(
-    r"(?P<prop>\b(?:fill|stroke)\s*:\s*)url\(#(?P<id>[^)]+)\)", re.IGNORECASE
-)
-
-ET.register_namespace("", SVG_NS)
-ET.register_namespace("xlink", XLINK_NS)
-
-_IMAGE_CACHE_DIR = ROOT_DIR / "images"
-load_dotenv(ROOT_DIR / ".env")
+from backend.app import config, rhymes, svg_processing
+from backend.app.svg_processing import SvgDocument as _SvgDocument
 
 logger = logging.getLogger(__name__)
-RHYME_SVG_BASE_PATH = Path(r"\\pixartnas\home\RHYMES & STORIES\NEW\Rhymes\SVGs")
-DEFAULT_COVER_SVG_BASE_PATH = Path(
-    r"\\pixartnas\home\Project ABC\Project ABC Cover\background\Sample"
-)
-PACKAGED_COVER_SVG_BASE_PATH = ROOT_DIR / "sample_cover_assets"
+
+ROOT_DIR = config.ROOT_DIR
+RHYME_SVG_BASE_PATH = config.RHYME_SVG_BASE_PATH
+COVER_SVG_BASE_PATH = config.resolve_cover_svg_base_path()
+
+RHYMES_DATA = rhymes.RHYMES_DATA
+generate_rhyme_svg = rhymes.generate_rhyme_svg
+
+_sanitize_svg_for_svglib = svg_processing.sanitize_svg_for_svglib
+_svg_requires_raster_backend = svg_processing.svg_requires_raster_backend
+_build_cover_asset_manifest = svg_processing.build_cover_asset_manifest
+_localize_svg_image_assets = svg_processing.localize_svg_image_assets
 
 
-@dataclass(frozen=True)
-class _SvgDocument:
-    """Container describing SVG markup and, optionally, its source path."""
-
-    markup: str
-    source_path: Optional[Path]
+def _ensure_image_cache_dir() -> Path:
+    return svg_processing.ensure_image_cache_dir(config.IMAGE_CACHE_DIR)
 
 
 def _resolve_rhyme_svg_path(rhyme_code: str) -> Optional[Path]:
-    """Return the network SVG path for ``rhyme_code`` if it exists."""
-
-    candidate = RHYME_SVG_BASE_PATH / f"{rhyme_code}.svg"
-
-    try:
-        if candidate.is_file():
-            return candidate
-
-        if candidate.exists():
-            logger.warning(
-                "Authored SVG for rhyme %s exists at %s but is not a file.",
-                rhyme_code,
-                candidate,
-            )
-        else:
-            logger.warning(
-                "SVG file not found for rhyme %s in %s (expected %s)",
-                rhyme_code,
-                RHYME_SVG_BASE_PATH,
-                candidate,
-            )
-    except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
-        logger.error(
-            "Unable to access SVG for rhyme %s at %s: %s",
-            rhyme_code,
-            candidate,
-            exc,
-        )
-
-    return None
-
-
-def _resolve_cover_svg_base_path() -> Optional[Path]:
-    """Return the configured base path for cover SVG assets, if any."""
-
-    candidate_paths: List[Optional[Path]] = []
-
-    base_path = r"pixartnas\home\Project ABC\Project ABC Cover\background\Sample\1 Theme\Theme 1 Test\SVGs"
-    print(base_path)
-    if base_path:
-        try:
-            candidate_paths.append(Path(base_path).expanduser())
-        except (OSError, RuntimeError) as exc:
-            logger.warning("Invalid COVER_SVG_BASE_PATH '%s': %s", base_path, exc)
-
-    candidate_paths.append(DEFAULT_COVER_SVG_BASE_PATH)
-    candidate_paths.append(PACKAGED_COVER_SVG_BASE_PATH)
-
-    for candidate in candidate_paths:
-        if not candidate:
-            continue
-
-        try:
-            if candidate.exists() and candidate.is_dir():
-                return candidate
-        except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
-            logger.warning("Unable to access cover SVG directory %s: %s", candidate, exc)
-
-    return None
-
-
-COVER_SVG_BASE_PATH = _resolve_cover_svg_base_path()
+    return svg_processing.resolve_rhyme_svg_path(RHYME_SVG_BASE_PATH, rhyme_code)
 
 
 def _ensure_cover_assets_base_path() -> Path:
-    """Return the configured cover assets directory or raise an HTTP error."""
+    return config.ensure_cover_assets_base_path(COVER_SVG_BASE_PATH)
 
-    if COVER_SVG_BASE_PATH is None:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "COVER_SVG_BASE_PATH is not configured on the server. "
-                "Please set it to the directory containing the cover SVG files."
-            ),
-        )
 
-    if not COVER_SVG_BASE_PATH.exists() or not COVER_SVG_BASE_PATH.is_dir():
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "The configured COVER_SVG_BASE_PATH does not exist or is not a directory."
-            ),
-        )
+def _load_rhyme_svg_markup(rhyme_code: str) -> _SvgDocument:
+    return svg_processing.load_rhyme_svg_markup(
+        rhyme_code, RHYME_SVG_BASE_PATH, fallback_factory=generate_rhyme_svg
+    )
 
-    return COVER_SVG_BASE_PATH
 
+def _normalize_cors_origin(origin: str) -> Optional[str]:
+    return config._normalize_cors_origin(origin)
 
-def _build_cover_asset_manifest(base_path: Path, *, include_markup: bool = False) -> List[Dict[str, Any]]:
-    """Build a manifest describing all SVG cover assets under ``base_path``.
 
-    Parameters
-    ----------
-    base_path:
-        Root directory that contains the cover SVG files.
-    include_markup:
-        When ``True`` the SVG markup for each asset is embedded directly in the
-        manifest. The existing API contract – file metadata and relative URLs –
-        remains unchanged so the frontend continues to function without
-        modification. This flag is enabled for the manifest endpoint so callers
-        that expect the raw SVG (e.g. when the files are hosted on a network
-        share) receive it without needing to perform an additional request per
-        asset.
-    """
-
-    assets: List[Dict[str, Any]] = []
-
-    for svg_path in sorted(base_path.rglob("*.svg")):
-        if not svg_path.is_file():
-            continue
-
-        try:
-            relative_path = svg_path.relative_to(base_path)
-        except ValueError:
-            # Skip files that fall outside the configured base directory.
-            continue
-
-        relative_posix = relative_path.as_posix()
-        manifest_entry: Dict[str, Any] = {
-            "fileName": svg_path.name,
-            "path": relative_posix,
-            "url": f"/api/cover-assets/svg/{quote(relative_posix, safe='/')}",
-        }
-
-        if include_markup:
-            try:
-                svg_text = svg_path.read_text(encoding="utf-8")
-            except UnicodeDecodeError:
-                # Fall back to decoding with replacement characters so a single
-                # mis-encoded file does not break the entire manifest.
-                svg_text = svg_path.read_bytes().decode("utf-8", errors="replace")
-            except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
-                logger.error("Unable to read cover SVG '%s': %s", svg_path, exc)
-                svg_text = ""
-
-            manifest_entry["svg"] = svg_text
-
-        assets.append(manifest_entry)
-
-    return assets
-
-
-def _parse_style_declarations(style: str) -> List[Tuple[str, str]]:
-    """Return the CSS declarations contained in ``style`` preserving order."""
-
-    declarations: List[Tuple[str, str]] = []
-    for raw_entry in style.split(";"):
-        if not raw_entry.strip():
-            continue
-
-        if ":" not in raw_entry:
-            continue
-
-        property_name, value = raw_entry.split(":", 1)
-        declarations.append((property_name.strip(), value.strip()))
-
-    return declarations
-
-
-def _serialize_style_declarations(declarations: List[Tuple[str, str]]) -> str:
-    """Serialize ``declarations`` back into an inline CSS string."""
-
-    return ";".join(f"{name}:{value}" for name, value in declarations)
-
-
-def _collect_gradient_fallback_colors(root: ET.Element) -> Dict[str, str]:
-    """Return a mapping of gradient ids to representative stop colours."""
-
-    gradient_colors: Dict[str, str] = {}
-    stop_xpath = f".//{{{SVG_NS}}}stop"
-
-    for gradient_tag in (
-        f".//{{{SVG_NS}}}linearGradient",
-        f".//{{{SVG_NS}}}radialGradient",
-    ):
-        for gradient in root.findall(gradient_tag):
-            gradient_id = gradient.attrib.get("id")
-            if not gradient_id or gradient_id in gradient_colors:
-                continue
-
-            representative_color: Optional[str] = None
-
-            for stop in gradient.findall(stop_xpath):
-                style = stop.attrib.get("style")
-                color: Optional[str] = None
-
-                if style:
-                    for name, value in _parse_style_declarations(style):
-                        if name == "stop-color" and value:
-                            color = value
-                            break
-
-                if color is None:
-                    color = stop.attrib.get("stop-color")
-
-                if color:
-                    representative_color = color
-                    break
-
-            if representative_color:
-                gradient_colors[gradient_id] = representative_color
-
-    return gradient_colors
-
-
-def _replace_gradient_references(element: ET.Element, gradient_colors: Dict[str, str]) -> bool:
-    """Replace gradient ``url(#id)`` colour references on ``element`` when possible."""
-
-    updated = False
-
-    for attribute in ("fill", "stroke"):
-        raw_value = element.attrib.get(attribute)
-        if not raw_value:
-            continue
-
-        match = _GRADIENT_URL_RE.match(raw_value.strip())
-        if not match:
-            continue
-
-        gradient_id = match.group("id")
-        fallback = gradient_colors.get(gradient_id)
-        if not fallback:
-            continue
-
-        element.set(attribute, fallback)
-        updated = True
-
-    style_value = element.attrib.get("style")
-    if style_value:
-        declarations = _parse_style_declarations(style_value)
-        new_declarations: List[Tuple[str, str]] = []
-        style_updated = False
-
-        for name, value in declarations:
-            match = _GRADIENT_URL_RE.match(value)
-            if match and name in {"fill", "stroke"}:
-                fallback = gradient_colors.get(match.group("id"))
-                if fallback:
-                    value = fallback
-                    style_updated = True
-            new_declarations.append((name, value))
-
-        if style_updated:
-            element.set("style", _serialize_style_declarations(new_declarations))
-            updated = True
-
-    return updated
-
-
-def _replace_gradient_references_in_css(
-    css_text: str, gradient_colors: Dict[str, str]
-) -> Tuple[str, bool]:
-    """Replace ``fill``/``stroke`` gradient references inside inline CSS blocks."""
-
-    updated = False
-
-    def _replace(match: re.Match[str]) -> str:
-        gradient_id = match.group("id")
-        fallback = gradient_colors.get(gradient_id)
-        if not fallback:
-            return match.group(0)
-
-        nonlocal updated
-        updated = True
-        return f"{match.group('prop')}{fallback}"
-
-    return _CSS_GRADIENT_DECLARATION_RE.sub(_replace, css_text), updated
-
-
-def _sanitize_svg_for_svglib(svg_markup: str) -> str:
-    """Replace unsupported gradient colour references with solid colours."""
-
-    try:
-        root = ET.fromstring(svg_markup)
-    except ET.ParseError:
-        return svg_markup
-
-    gradient_colors = _collect_gradient_fallback_colors(root)
-    if not gradient_colors:
-        return svg_markup
-
-    updated = False
-    for element in root.iter():
-        if _replace_gradient_references(element, gradient_colors):
-            updated = True
-            continue
-
-        if element.tag == f"{{{SVG_NS}}}style" and element.text:
-            replaced_text, css_updated = _replace_gradient_references_in_css(
-                element.text, gradient_colors
-            )
-            if css_updated:
-                element.text = replaced_text
-                updated = True
-
-    if not updated:
-        return svg_markup
-
-    return ET.tostring(root, encoding="unicode")
-
-
-def _svg_requires_raster_backend(svg_document: _SvgDocument) -> bool:
-    """Return ``True`` when the SVG should be rasterised for PDF output.
-
-    ReportLab's PDF canvas (used through ``svglib``) cannot represent alpha
-    channels for embedded PNG images which results in black rectangles around
-    artwork. The helper inspects the markup to detect common PNG usage (file
-    paths, data URIs or explicit ``type`` attributes) and signals that the
-    raster CairoSVG fallback should be preferred instead. The routine is also
-    leveraged to bypass vector rendering when transparency would be lost.
-    """
-
-    try:
-        root = ET.fromstring(svg_document.markup)
-    except ET.ParseError:
-        return False
-
-    image_xpath = f".//{{{SVG_NS}}}image"
-
-    for image in root.findall(image_xpath):
-        href_value = (
-            image.get(f"{{{XLINK_NS}}}href")
-            or image.get("href")
-            or ""
-        ).strip()
-        if not href_value:
-            continue
-
-        href_lower = href_value.lower()
-        if href_lower.startswith("data:"):
-            if href_lower.startswith("data:image/png") or href_lower.startswith(
-                "data:image/apng"
-            ):
-                return True
-        else:
-            parsed = urlparse(href_value)
-            candidate = (parsed.path or href_value).lower()
-            if candidate.endswith((".png", ".apng")):
-                return True
-
-        type_attr = (image.get("type") or "").lower()
-        if type_attr in {"image/png", "image/apng"}:
-            return True
-
-    return False
-
+def _parse_csv(value: Optional[str], *, default: Optional[List[str]] = None) -> List[str]:
+    return config._parse_csv(value, default=default)
 
 # MongoDB connection
 mongo_url = os.environ["MONGO_URL"]
 client = AsyncIOMotorClient(mongo_url)
 db = client[os.environ["DB_NAME"]]
-
-# Load rhymes data
-with open(ROOT_DIR / "rhymes.json", "r") as f:
-    RHYMES_DATA = json.load(f)
-
-
-def generate_rhyme_svg(rhyme_code: str) -> str:
-    """Create SVG markup for a rhyme card.
-
-    This helper centralizes the SVG generation so that both the API endpoint
-    returning individual SVGs and the binder export can share the same layout.
-    """
-
-    if rhyme_code not in RHYMES_DATA:
-        raise KeyError("Rhyme not found")
-
-    rhyme_name = RHYMES_DATA[rhyme_code][0]
-
-    return f"""
-    <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-            <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style="stop-color:#ff6b6b;stop-opacity:1" />
-                <stop offset="100%" style="stop-color:#4ecdc4;stop-opacity:1" />
-            </linearGradient>
-        </defs>
-        <rect width="400" height="300" fill="url(#grad1)" rx="15"/>
-        <text x="200" y="100" font-family="Arial, sans-serif" font-size="16" font-weight="bold"
-              text-anchor="middle" fill="white">{rhyme_name}</text>
-        <text x="200" y="130" font-family="Arial, sans-serif" font-size="12"
-              text-anchor="middle" fill="white">Code: {rhyme_code}</text>
-        <text x="200" y="160" font-family="Arial, sans-serif" font-size="12"
-              text-anchor="middle" fill="white">Pages: {RHYMES_DATA[rhyme_code][1]}</text>
-        <circle cx="200" cy="220" r="30" fill="rgba(255,255,255,0.3)" stroke="white" stroke-width="2"/>
-        <text x="200" y="225" font-family="Arial, sans-serif" font-size="20"
-              text-anchor="middle" fill="white">♪</text>
-    </svg>
-    """
-
-
-def _ensure_image_cache_dir() -> Path:
-    """Return the local image cache directory, creating it if needed."""
-
-    try:
-        _IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:  # pragma: no cover - filesystem permissions errors
-        logger.error("Unable to create image cache directory %s: %s", _IMAGE_CACHE_DIR, exc)
-        raise
-
-    return _IMAGE_CACHE_DIR
-
-
-def _prepare_inline_image_asset(
-    asset_path: Path,
-    rhyme_code: str,
-    *,
-    preprocess_for_pdf: bool = False,
-) -> Optional[Tuple[bytes, str]]:
-    """Return image bytes and mime type for embedding in SVG."""
-
-    if preprocess_for_pdf:
-        suffix = asset_path.suffix.lower()
-        try:
-            if suffix in {".png", ".apng"}:
-                with Image.open(asset_path) as image:
-                    prepared = image.convert("RGBA")
-                    buffer = BytesIO()
-                    prepared.save(buffer, format="PNG")
-                    return buffer.getvalue(), "image/png"
-            if suffix in {".jpg", ".jpeg"}:
-                with Image.open(asset_path) as image:
-                    rgba_image = image.convert("RGBA")
-                    background = Image.new("RGBA", rgba_image.size, (255, 255, 255, 255))
-                    background.alpha_composite(rgba_image)
-                    buffer = BytesIO()
-                    background.save(buffer, format="PNG")
-                    return buffer.getvalue(), "image/png"
-        except (OSError, ValueError) as exc:
-            logger.warning(
-                "Failed to preprocess bitmap asset '%s' for rhyme %s at %s: %s",
-                asset_path.name,
-                rhyme_code,
-                asset_path,
-                exc,
-            )
-
-    try:
-        raw_bytes = asset_path.read_bytes()
-    except OSError as exc:
-        logger.warning(
-            "Unable to read bitmap asset '%s' for rhyme %s at %s: %s",
-            asset_path.name,
-            rhyme_code,
-            asset_path,
-            exc,
-        )
-        return None
-
-    mime_type, _ = mimetypes.guess_type(asset_path.name)
-    if preprocess_for_pdf and mime_type is None:
-        # Default to PNG when preprocessing failed to determine the type.
-        mime_type = "image/png"
-    if not mime_type:
-        mime_type = "application/octet-stream"
-
-    return raw_bytes, mime_type
-
-
-def _localize_svg_image_assets(
-    svg_text: str,
-    svg_path: Path,
-    rhyme_code: str,
-    *,
-    inline_mode: bool = False,
-    preprocess_for_pdf: bool = False,
-) -> str:
-    """Rewrite referenced raster asset URIs so downstream consumers can load them.
-
-    When ``inline_mode`` is ``False`` the function mirrors bitmap dependencies into a
-    local cache directory and rewrites their references to ``file://`` URIs. This is
-    primarily used while generating PDFs where the renderer can dereference files on
-    disk. When ``inline_mode`` is ``True`` the helper instead embeds the images as
-    ``data:`` URIs which can be displayed directly in browsers without additional
-    HTTP endpoints. When ``preprocess_for_pdf`` is enabled the routine normalizes
-    referenced PNG assets to preserve their alpha channels and converts JPEG images
-    to PNG with a white background so that CairoSVG renders them without opaque
-    artefacts when generating PDFs.
-    """
-
-    try:
-        root = ET.fromstring(svg_text)
-    except ET.ParseError as exc:
-        logger.warning(
-            "Failed to parse SVG for rhyme %s at %s: %s", rhyme_code, svg_path, exc
-        )
-        return svg_text
-
-    images = list(root.findall(f".//{{{SVG_NS}}}image"))
-    if not images:
-        return svg_text
-
-    cache_dir: Optional[Path] = None
-    if not inline_mode:
-        try:
-            cache_dir = _ensure_image_cache_dir()
-        except OSError:
-            # Directory creation failure already logged in _ensure_image_cache_dir.
-            return svg_text
-
-    modified = False
-
-    for image in images:
-        href_value = image.get(f"{{{XLINK_NS}}}href") or image.get("href")
-        if not href_value:
-            continue
-
-        href_value = href_value.strip()
-        if href_value.startswith("data:"):
-            continue
-
-        parsed = urlparse(href_value)
-        if parsed.scheme and parsed.scheme != "file":
-            logger.debug(
-                "Skipping non-file image reference '%s' in %s", href_value, svg_path
-            )
-            continue
-
-        raw_path = unquote(parsed.path or href_value)
-        if not raw_path:
-            logger.debug("Skipping empty image reference in %s", svg_path)
-            continue
-        if parsed.scheme == "file" and parsed.netloc:
-            logger.warning(
-                "Skipping network file reference '%s' in %s", href_value, svg_path
-            )
-            continue
-
-        if parsed.scheme == "file":
-            asset_path = Path(raw_path)
-        else:
-            candidate = Path(raw_path)
-            if candidate.is_absolute():
-                asset_path = candidate
-            else:
-                asset_path = (svg_path.parent / candidate).resolve()
-
-        try:
-            src_stat = asset_path.stat()
-        except FileNotFoundError:
-            logger.warning(
-                "Bitmap asset '%s' for rhyme %s not found at %s", href_value, rhyme_code, asset_path
-            )
-            continue
-        except OSError as exc:  # pragma: no cover - unexpected filesystem error
-            logger.warning(
-                "Unable to access bitmap asset '%s' for rhyme %s at %s: %s",
-                href_value,
-                rhyme_code,
-                asset_path,
-                exc,
-            )
-            continue
-
-        if inline_mode:
-            prepared = _prepare_inline_image_asset(
-                asset_path,
-                rhyme_code,
-                preprocess_for_pdf=preprocess_for_pdf,
-            )
-            if not prepared:
-                continue
-
-            raw_bytes, mime_type = prepared
-            data64 = base64.b64encode(raw_bytes).decode("ascii")
-            new_href = f"data:{mime_type};base64,{data64}"
-        else:
-            assert cache_dir is not None
-            destination = cache_dir / f"{rhyme_code}_{asset_path.name}"
-
-            copy_required = True
-            try:
-                dest_stat = destination.stat()
-            except FileNotFoundError:
-                pass
-            except OSError as exc:  # pragma: no cover - unexpected filesystem error
-                logger.warning(
-                    "Unable to access cached bitmap for rhyme %s at %s: %s",
-                    rhyme_code,
-                    destination,
-                    exc,
-                )
-            else:
-                if (
-                    dest_stat.st_mtime >= src_stat.st_mtime
-                    and dest_stat.st_size == src_stat.st_size
-                ):
-                    copy_required = False
-
-            if copy_required:
-                try:
-                    copy2(asset_path, destination)
-                except OSError as exc:
-                    logger.warning(
-                        "Unable to copy bitmap asset '%s' for rhyme %s to %s: %s",
-                        href_value,
-                        rhyme_code,
-                        destination,
-                        exc,
-                    )
-                    continue
-
-            try:
-                new_href = destination.resolve().as_uri()
-            except OSError as exc:  # pragma: no cover - resolution errors unexpected
-                logger.warning(
-                    "Unable to resolve cached bitmap URI for rhyme %s at %s: %s",
-                    rhyme_code,
-                    destination,
-                    exc,
-                )
-                continue
-
-        image.set(f"{{{XLINK_NS}}}href", new_href)
-        image.set("href", new_href)
-        modified = True
-
-    if not modified:
-        return svg_text
-
-    return ET.tostring(root, encoding="unicode")
-
-
-def _load_rhyme_svg_markup(rhyme_code: str) -> _SvgDocument:
-    """Return SVG markup and optional source path for ``rhyme_code``.
-
-    When a filesystem base path is configured the function prefers loading the
-    authored SVG asset so the generated PDF binder can embed the authentic
-    artwork. The markup is returned alongside its originating path so downstream
-    renderers can resolve relative bitmap references without rewriting ``href``
-    attributes. If the asset is missing the helper falls back to
-    :func:`generate_rhyme_svg`.
-    """
-
-    svg_path = _resolve_rhyme_svg_path(rhyme_code)
-
-    if svg_path is not None:
-        try:
-
-            svg_text = svg_path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            logger.warning("SVG file not found for rhyme %s at %s", rhyme_code, svg_path)
-        except OSError as exc:  # pragma: no cover - filesystem errors are unexpected
-            logger.error("Unable to read SVG for rhyme %s at %s: %s", rhyme_code, svg_path, exc)
-        else:
-            return _SvgDocument(svg_text, svg_path)
-
-
-
-    return _SvgDocument(generate_rhyme_svg(rhyme_code), None)
-
-
-def _normalize_cors_origin(origin: str) -> Optional[str]:
-    """Return a sanitized representation of a configured CORS origin."""
-
-    trimmed = origin.strip()
-    if not trimmed:
-        return None
-
-    if trimmed == "*":
-        return trimmed
-
-    return trimmed.rstrip("/")
-
-
-def _parse_csv(value: Optional[str], *, default: Optional[List[str]] = None) -> List[str]:
-    """Return a normalized list from a comma separated string."""
-
-    def _collect(entries: Iterable[str]) -> List[str]:
-        normalized: List[str] = []
-        seen: Set[str] = set()
-
-        for raw_entry in entries:
-            normalized_entry = _normalize_cors_origin(raw_entry)
-            if not normalized_entry or normalized_entry in seen:
-                continue
-
-            normalized.append(normalized_entry)
-            seen.add(normalized_entry)
-
-        return normalized
-
-    if value is not None:
-        parsed = _collect(value.split(","))
-        if parsed:
-            return parsed
-
-    return _collect(default or [])
-
 
 app = FastAPI()
 app.add_middleware(
@@ -758,7 +74,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
 
 
 class PDFDependencyUnavailableError(RuntimeError):
@@ -1369,7 +684,6 @@ async def get_rhyme_svg(rhyme_code: str):
 
 @api_router.get("/cover-assets/manifest")
 async def get_cover_assets_manifest():
-    print("Iam called")
     """Return a manifest describing all available cover SVG assets."""
 
     base_path = _ensure_cover_assets_base_path()
@@ -1516,22 +830,35 @@ def _render_svg_on_canvas(
     y: float = 0,
     rhyme_code: Optional[str] = None,
 ) -> bool:
-    """Render ``svg_markup`` onto ``pdf_canvas`` using the available backend.
-
-    Returns ``True`` when the SVG could be rendered, ``False`` otherwise. The
-    function prefers drawing vector content via svglib when available before
-    falling back to rasterising the SVG with CairoSVG.
-    """
+    """Render ``svg_document`` onto ``pdf_canvas`` using the available backend."""
 
     logger = logging.getLogger(__name__)
 
-    svg_markup = svg_document.markup
+    original_markup = svg_document.markup
+    effective_markup = original_markup
     source_path = svg_document.source_path
-    sanitized_markup = _sanitize_svg_for_svglib(svg_markup)
+
+    sanitized_markup = _sanitize_svg_for_svglib(effective_markup)
+    if sanitized_markup != effective_markup:
+        effective_markup = sanitized_markup
+
     raster_only = _svg_requires_raster_backend(svg_document)
 
-    if sanitized_markup != svg_markup:
-        raster_only = True
+    if source_path is not None:
+        localized_markup = _localize_svg_image_assets(
+            effective_markup,
+            source_path,
+            rhyme_code or "unknown",
+            inline_mode=True,
+            preprocess_for_pdf=True,
+        )
+        if localized_markup != effective_markup:
+            effective_markup = localized_markup
+
+    if effective_markup != original_markup:
+        raster_only = _svg_requires_raster_backend(_SvgDocument(effective_markup, source_path))
+
+    needs_temp_file = source_path is not None and effective_markup != original_markup
 
     vector_backend_available = (
         backend.svg2rlg
@@ -1539,25 +866,13 @@ def _render_svg_on_canvas(
         and not raster_only
     )
 
-    if source_path is not None:
-        localized_markup = _localize_svg_image_assets(
-            sanitized_markup,
-            source_path,
-            rhyme_code or "unknown",
-            inline_mode=True,
-            preprocess_for_pdf=True,
-        )
-        if localized_markup != sanitized_markup:
-            sanitized_markup = localized_markup
-
     temp_svg_path: Optional[Path] = None
 
     if vector_backend_available:
         try:
             svg_input: Any
             if source_path is not None:
-                if sanitized_markup != svg_markup:
-                    temp_svg_path = None
+                if needs_temp_file:
                     candidate_dirs: List[Path] = []
                     parent_dir = source_path.parent
                     if parent_dir.exists() and parent_dir.is_dir():
@@ -1579,7 +894,7 @@ def _render_svg_on_canvas(
                                 dir=directory,
                                 delete=False,
                             ) as temp_file:
-                                temp_file.write(sanitized_markup)
+                                temp_file.write(effective_markup)
                             temp_svg_path = Path(temp_file.name)
                             break
                         except OSError as exc:
@@ -1593,13 +908,13 @@ def _render_svg_on_canvas(
                         logger.warning(
                             "Falling back to in-memory sanitized SVG for %s", source_path
                         )
-                        svg_input = BytesIO(sanitized_markup.encode("utf-8"))
+                        svg_input = BytesIO(effective_markup.encode("utf-8"))
                     else:
                         svg_input = str(temp_svg_path)
                 else:
                     svg_input = str(source_path)
             else:
-                svg_input = BytesIO(sanitized_markup.encode("utf-8"))
+                svg_input = BytesIO(effective_markup.encode("utf-8"))
 
             drawing = backend.svg2rlg(svg_input)
         except Exception as exc:  # pragma: no cover - defensive logging
@@ -1637,10 +952,10 @@ def _render_svg_on_canvas(
     ):
         try:
             image_buffer = BytesIO()
-            cairosvg_markup = svg_markup
+            cairosvg_markup = effective_markup
             if svg_document.source_path is not None:
                 cairosvg_markup = _localize_svg_image_assets(
-                    svg_markup,
+                    cairosvg_markup,
                     svg_document.source_path,
                     rhyme_code or "unknown",
                     inline_mode=True,


### PR DESCRIPTION
## Summary
- extract reusable configuration, rhyme catalogue, and SVG helpers into a new backend.app package
- update backend.server to delegate to the shared helpers while preserving its public API
- refine SVG rendering to work with inlined assets and optional fallbacks during PDF export

## Testing
- pytest tests/test_rhyme_svg_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68dfb02bc40c832582a083d19b0f8b91