### PR TITLE
Fix backend package import failure

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,6 @@
+"""Backend package initialization for FastAPI application."""
+
+# Expose commonly used modules for convenient imports when the package is loaded.
+from . import app  # noqa: F401
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add a backend package initializer so the FastAPI server can import backend.app modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfb872a314832586e5cbd5fd31fe1e