### PR TITLE
Add top padding to cover preview card content

### DIFF
--- a/frontend/src/components/CoverPageWorkflow.jsx
+++ b/frontend/src/components/CoverPageWorkflow.jsx
@@ -939,7 +939,7 @@ const CoverPageWorkflow = ({ school, grade, onBackToGrades, onBackToMode, onLogo
                   Browse the personalised artwork using the carousel controls below.
                 </p>
               </CardHeader>
-              <CardContent className="space-y-6">
+              <CardContent className="space-y-6 pt-6">
                 {isFetchingAssets && (
                   <div className="cover-carousel-stage">
                     <Skeleton className="h-full w-full" />


### PR DESCRIPTION
## Summary
- ensure the cover preview card content keeps top padding so the personalised SVG is not flush with the header

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dfbbcee9948325aed86f1ce4f3d95a