### PR TITLE
Add sample cover asset structure for cover API

### DIFF
--- a/backend/sample_cover_assets/(1 Theme/Theme 1/SVGs/Colour 1)/sample-cover.svg
+++ b/backend/sample_cover_assets/(1 Theme/Theme 1/SVGs/Colour 1)/sample-cover.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6a11cb" />
+      <stop offset="100%" stop-color="#2575fc" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" rx="24" fill="url(#bg)" />
+  <text x="200" y="150" font-family="Arial, sans-serif" font-size="32" text-anchor="middle" fill="#ffffff">
+    Sample Cover
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add a packaged cover asset directory that mirrors the expected theme/colour structure
- include a sample SVG so the cover asset network endpoint can resolve selection 1.1 during local development

## Testing
- pytest *(fails: missing `requests` test dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0f7a8f67c832594690f54e4308bc7