### PR TITLE
Refactor authentication into dedicated module

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,9 +6,10 @@ structure keeps the deployment entry-point stable while allowing the codebase
 to grow in a maintainable fashion.
 """
 
-from . import config, rhymes, svg_processing
+from . import auth, config, rhymes, svg_processing
 
 __all__ = [
+    "auth",
     "config",
     "rhymes",
     "svg_processing",

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,47 @@
+"""Authentication models and router for the Rhymes application."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+
+class School(BaseModel):
+    """Representation of a school registered with the application."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    school_id: str
+    school_name: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class SchoolCreate(BaseModel):
+    """Input model for registering a new school."""
+
+    school_id: str
+    school_name: str
+
+
+def create_auth_router(db) -> APIRouter:
+    """Create and return a router exposing authentication endpoints."""
+
+    router = APIRouter(prefix="/auth", tags=["auth"])
+
+    @router.post("/login", response_model=School)
+    async def login_school(input: SchoolCreate):
+        """Register a school if it does not exist and return its record."""
+
+        existing_school = await db.schools.find_one({"school_id": input.school_id})
+
+        if existing_school:
+            return School(**existing_school)
+
+        school_dict = input.dict()
+        school_obj = School(**school_dict)
+        await db.schools.insert_one(school_obj.dict())
+        return school_obj
+
+    return router

--- a/backend/server.py
+++ b/backend/server.py
@@ -28,11 +28,13 @@ if __package__ in {None, ""}:
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
 
-    from backend.app import config, rhymes, svg_processing  # type: ignore
+    from backend.app import auth, config, rhymes, svg_processing  # type: ignore
     from backend.app.svg_processing import SvgDocument as _SvgDocument  # type: ignore
 else:  # pragma: no cover - exercised only during normal package imports
-    from .app import config, rhymes, svg_processing
+    from .app import auth, config, rhymes, svg_processing
     from .app.svg_processing import SvgDocument as _SvgDocument
+
+School = auth.School
 
 logger = logging.getLogger(__name__)
 
@@ -200,21 +202,10 @@ def _load_pdf_dependencies() -> _PdfResources:
 
 # Create a router with the /api prefix
 api_router = APIRouter(prefix="/api")
+api_router.include_router(auth.create_auth_router(db))
 
 
 # Models
-class School(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    school_id: str
-    school_name: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
-
-
-class SchoolCreate(BaseModel):
-    school_id: str
-    school_name: str
-
-
 class RhymeSelection(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     school_id: str
@@ -255,22 +246,6 @@ class SchoolWithSelections(School):
     total_selections: int = 0
     last_updated: Optional[datetime] = None
     grades: Dict[str, List[RhymeSelectionDetail]] = Field(default_factory=dict)
-
-
-# Authentication endpoints
-@api_router.post("/auth/login", response_model=School)
-async def login_school(input: SchoolCreate):
-    # Check if school already exists
-    existing_school = await db.schools.find_one({"school_id": input.school_id})
-
-    if existing_school:
-        return School(**existing_school)
-
-    # Create new school entry
-    school_dict = input.dict()
-    school_obj = School(**school_dict)
-    await db.schools.insert_one(school_obj.dict())
-    return school_obj
 
 
 # Rhymes data endpoints


### PR DESCRIPTION
## Summary
- add a dedicated `backend/app/auth.py` module that encapsulates the school models and login endpoint
- update the FastAPI server to source the authentication router from the new module and re-export the auth package helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests'; ImportError: cannot import name 'APIRouter' from 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_b_68e36ba2e01083258830ed5e5acd017e