### PR TITLE
Collect cover page defaults before grade selection

### DIFF
--- a/frontend/src/lib/fileUtils.js
+++ b/frontend/src/lib/fileUtils.js
@@ -1,0 +1,26 @@
+export const readFileAsDataUrl = (file) =>
+  new Promise((resolve, reject) => {
+    if (!file) {
+      resolve('');
+      return;
+    }
+
+    if (typeof FileReader === 'undefined') {
+      reject(new Error('FileReader is not supported in this environment.'));
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      resolve(result);
+    };
+    reader.onerror = () => {
+      reject(reader.error || new Error('Unable to read file.'));
+    };
+    reader.onabort = () => {
+      reject(new Error('File reading was aborted.'));
+    };
+
+    reader.readAsDataURL(file);
+  });


### PR DESCRIPTION
## Summary
- add a cover workflow pre-flight form on the grade selection screen so common details are captured once
- persist the shared cover details in app state and feed them into the cover page workflow
- show the saved defaults in the cover details step, restrict editing there, and share file reading logic via a new utility

## Testing
- yarn test --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68e36b130e788325b1f52c4f93f6619f