### PR TITLE
Fix hook invocation order in GradeSelectionPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -434,17 +434,6 @@ const GradeSelectionPage = ({
     }
   };
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-16 h-16 border-4 border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading grade information...</p>
-        </div>
-      </div>
-    );
-  }
-
   const handleLogoutClick = () => {
     if (typeof onLogout === 'function') {
       onLogout();
@@ -472,6 +461,17 @@ const GradeSelectionPage = ({
     },
     [coverDefaultsComplete, isCoverMode, mode, onGradeSelect]
   );
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 border-4 border-orange-400 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading grade information...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-red-50 p-6">


### PR DESCRIPTION
## Summary
- ensure all hooks in `GradeSelectionPage` are declared before any conditional return to keep the hook order stable
- move the grade card selection callback above the loading guard so it is always registered

## Testing
- CI=1 yarn test --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68e37011b6f083259838fb513471c608