### PR TITLE
Fix binder download button event propagation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -417,10 +417,7 @@ const GradeSelectionPage = ({
     return status ? `${status.selected_count} of 25` : '0 of 25';
   };
 
-  const handleDownloadBinder = async (gradeId, event) => {
-    event?.stopPropagation();
-    event?.preventDefault();
-
+  const handleDownloadBinder = async (gradeId) => {
     try {
       const response = await axios.get(`${API}/rhymes/binder/${school.school_id}/${gradeId}`, {
         responseType: 'blob'
@@ -440,6 +437,12 @@ const GradeSelectionPage = ({
       console.error('Error downloading binder:', error);
       toast.error('Failed to download binder');
     }
+  };
+
+  const handleDownloadBinderClick = (gradeId) => (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    handleDownloadBinder(gradeId);
   };
 
   const handleLogoutClick = () => {
@@ -679,7 +682,9 @@ const GradeSelectionPage = ({
                         <Button
                           variant="outline"
                           type="button"
-                          onClick={(event) => handleDownloadBinder(grade.id, event)}
+                          onClick={handleDownloadBinderClick(grade.id)}
+                          onMouseDown={(event) => event.stopPropagation()}
+                          onTouchStart={(event) => event.stopPropagation()}
                           className="w-full flex items-center justify-center gap-2 border-orange-300 text-orange-500 hover:text-orange-600 hover:bg-orange-50 bg-white/90"
                         >
                           <Download className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- ensure the rhyme binder download button stops card click propagation
- keep download logic encapsulated and resilient to pointer events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4ed92c96c83258aeb234ceffafc12