### PR TITLE
Prevent binder download requests from being cached

### DIFF
--- a/frontend/src/Aoriginal.js
+++ b/frontend/src/Aoriginal.js
@@ -139,7 +139,10 @@ const GradeSelectionPage = ({ school, onGradeSelect, onLogout }) => {
 
     try {
       const response = await axios.get(`${API}/rhymes/binder/${school.school_id}/${gradeId}`, {
-        responseType: 'blob'
+        responseType: 'blob',
+        params: {
+          _t: Date.now()
+        }
       });
 
       const blob = new Blob([response.data], { type: 'application/pdf' });

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -611,7 +611,10 @@ const GradeSelectionPage = ({
   const handleDownloadBinder = async (gradeId) => {
     try {
       const response = await axios.get(`${API}/rhymes/binder/${school.school_id}/${gradeId}`, {
-        responseType: 'blob'
+        responseType: 'blob',
+        params: {
+          _t: Date.now()
+        }
       });
 
       const blob = new Blob([response.data], { type: 'application/pdf' });


### PR DESCRIPTION
## Summary
- ensure binder download requests include a cache-busting query parameter so the API is hit every time

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e5080d219c832598da88c53522f05a