### PR TITLE
Add page limit and static cover asset images

### DIFF
--- a/backend/app/svg_processing.py
+++ b/backend/app/svg_processing.py
@@ -400,6 +400,7 @@ def localize_svg_image_assets(
     inline_mode: bool = False,
     preprocess_for_pdf: bool = False,
     cache_dir: Optional[Path] = None,
+    asset_url_prefix: Optional[str] = None,
 ) -> str:
     """Return ``svg_text`` with external image references localised."""
 
@@ -467,6 +468,8 @@ def localize_svg_image_assets(
             continue
 
         new_href = cache_file.name
+        if asset_url_prefix:
+            new_href = f"{asset_url_prefix.rstrip('/')}/{cache_file.name}"
         image.set("href", new_href)
         image.set(f"{{{config.XLINK_NS}}}href", new_href)
         modified = True


### PR DESCRIPTION
## Summary
- serve cover asset bitmap resources as static files with a dedicated endpoint instead of embedding base64 data URIs
- update cover SVG localization to point to the new static image URLs
- adjust mode selection layout responsiveness and enforce a 44-page selection cap for rhymes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69292c4c618483259b3149011fa11953)